### PR TITLE
feat: publish docker image and release zip for self-hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+dev-dist
+.git
+.github
+*.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,139 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release-zip:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Resolve version
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+
+      - run: npm ci
+
+      - name: Build
+        env:
+          APP_VERSION: ${{ steps.meta.outputs.version }}
+        run: npm run build
+
+      - name: Package dist
+        run: |
+          cd dist
+          zip -r "../odio-pwa-${{ steps.meta.outputs.version }}.zip" .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: odio-pwa-${{ steps.meta.outputs.version }}.zip
+          generate_release_notes: true
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+
+  docker-build:
+    needs: release-zip
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Prepare platform pair
+        id: prep
+        run: |
+          platform=${{ matrix.platform }}
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.release-zip.outputs.version }}
+            REPO=${{ github.repository }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    needs: [release-zip, docker-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list
+        working-directory: /tmp/digests
+        run: |
+          TAGS=(-t "ghcr.io/${{ github.repository }}:${{ needs.release-zip.outputs.version }}")
+          if [[ "${{ needs.release-zip.outputs.prerelease }}" != "true" ]]; then
+            TAGS+=(-t "ghcr.io/${{ github.repository }}:latest")
+          fi
+          docker buildx imagetools create "${TAGS[@]}" \
+            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM nginx:alpine
+
+ARG VERSION
+ARG REPO
+
+ADD https://github.com/${REPO}/releases/download/v${VERSION}/odio-pwa-${VERSION}.zip /tmp/app.zip
+
+RUN apk add --no-cache unzip \
+ && rm -rf /usr/share/nginx/html/* \
+ && unzip /tmp/app.zip -d /usr/share/nginx/html \
+ && rm /tmp/app.zip \
+ && apk del unzip
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -119,6 +119,36 @@ The iframe loading `/ui` does **not** require CORS headers.
 
 The service worker caches only the app shell (HTML, CSS, JS, icons). It does not cache cross-origin requests to odio-api instances. The app is installable on supported browsers and works offline (showing the cached instance list — instances will appear as offline until the network is available).
 
+## Self-hosting
+
+A Docker image is published to GHCR for each `v*` tag, alongside a zip of the static build attached to the GitHub Release.
+
+### Docker (recommended)
+
+```bash
+docker run -d -p 8080:80 --restart unless-stopped \
+  --name odio-pwa ghcr.io/b0bbywan/odio-pwa:latest
+```
+
+The image is multi-arch (`linux/amd64`, `linux/arm64`) and ships an nginx configured for SPA routing and PWA cache headers.
+
+### Static zip
+
+Download `odio-pwa-<version>.zip` from the [Releases](https://github.com/b0bbywan/odio-pwa/releases) page and serve the extracted files with any static web server. Make sure to:
+
+- rewrite unknown routes to `/index.html` (SPA fallback)
+- serve `/index.html`, `/sw.js`, `/registerSW.js` with `Cache-Control: no-cache` so PWA updates propagate
+
+### HTTPS and mixed content
+
+The PWA makes **HTTP** calls to your odio-api instances on the LAN. When the PWA itself is served over HTTPS (e.g. behind a public reverse proxy), behavior varies by browser:
+
+- **Chrome 142+** shows a [Local Network Access](https://developer.chrome.com/blog/local-network-access) permission prompt on the first HTTP LAN call; granting it bypasses the mixed-content block for private IPs, `.local` domains, and loopback.
+- **Safari** (iOS/macOS) blocks mixed-content fetches strictly — [no LAN exemption in WebKit](https://bugs.webkit.org/show_bug.cgi?id=171934).
+- **Firefox** exempts `localhost` / `.localhost`, but private IPs are still blocked ([MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Mixed_content)).
+
+Serving the PWA over plain HTTP on the LAN avoids all of this.
+
 ## License
 
 [BSD-2-Clause](LICENSE)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ The PWA makes **HTTP** calls to your odio-api instances on the LAN. When the PWA
 
 Serving the PWA over plain HTTP on the LAN avoids all of this.
 
+### Update indicator
+
+The app checks GitHub for a newer stable release and shows an arrow next to the version when one is available. By default prereleases are ignored. To also surface prereleases (useful when testing an RC image), run this in the browser devtools:
+
+```js
+localStorage.setItem('odio-include-prereleases', 'true'); location.reload();
+```
+
+To revert: `localStorage.removeItem('odio-include-prereleases'); location.reload()`.
+
 ## License
 
 [BSD-2-Clause](LICENSE)

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    location = /sw.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    location = /registerSW.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-cache";
+    }
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    gzip on;
+    gzip_types
+        text/plain
+        text/css
+        application/javascript
+        application/json
+        image/svg+xml
+        application/manifest+json;
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,35 +1,66 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-
-	<defs>
-		<radialGradient id="cone" cx="50%" cy="45%" r="60%">
-			<stop offset="0%" stop-color="#b6ff66"></stop>
-			<stop offset="40%" stop-color="#4caf50"></stop>
-			<stop offset="100%" stop-color="#0d3d1e"></stop>
-		</radialGradient>
-
-		<linearGradient id="ring" x1="0" y1="0" x2="0" y2="1">
-			<stop offset="0%" stop-color="#8be44f"></stop>
-			<stop offset="100%" stop-color="#1e6b34"></stop>
-		</linearGradient>
-	</defs>
-
-	<!-- outer frame -->
-	<circle cx="256" cy="256" r="230" fill="#0b2d17"></circle>
-
-	<!-- rings -->
-	<circle cx="256" cy="256" r="200" fill="url(#ring)"></circle>
-	<circle cx="256" cy="256" r="175" fill="#0b2d17"></circle>
-	<circle cx="256" cy="256" r="150" fill="url(#ring)"></circle>
-	<circle cx="256" cy="256" r="120" fill="#0b2d17"></circle>
-
-	<!-- cone -->
-	<circle cx="256" cy="256" r="95" fill="url(#cone)"></circle>
-	<circle cx="256" cy="256" r="35" fill="#7bff55"></circle>
-
-	<!-- screws in corners -->
-	<circle cx="160" cy="160" r="10" fill="#0b2d17"></circle>
-	<circle cx="352" cy="160" r="10" fill="#0b2d17"></circle>
-	<circle cx="160" cy="352" r="10" fill="#0b2d17"></circle>
-	<circle cx="352" cy="352" r="10" fill="#0b2d17"></circle>
-
+  <defs>
+    <linearGradient id="ring-outer" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#3a8010"/>
+      <stop offset="50%"  stop-color="#7ec828"/>
+      <stop offset="100%" stop-color="#c8f060"/>
+    </linearGradient>
+    <linearGradient id="ring-mid" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#1e6020"/>
+      <stop offset="100%" stop-color="#8be030"/>
+    </linearGradient>
+    <linearGradient id="ring-inner" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#2a7030"/>
+      <stop offset="100%" stop-color="#5ab820"/>
+    </linearGradient>
+    <radialGradient id="cone" cx="62%" cy="68%" r="65%" gradientUnits="objectBoundingBox">
+      <stop offset="0%"   stop-color="#c0f040"/>
+      <stop offset="35%"  stop-color="#50a818"/>
+      <stop offset="70%"  stop-color="#0a3008"/>
+      <stop offset="100%" stop-color="#020c00"/>
+    </radialGradient>
+    <radialGradient id="dustcap" cx="62%" cy="68%" r="65%" gradientUnits="objectBoundingBox">
+      <stop offset="0%"   stop-color="#60c820"/>
+      <stop offset="60%"  stop-color="#1a5808"/>
+      <stop offset="100%" stop-color="#040e00"/>
+    </radialGradient>
+    <radialGradient id="screw" cx="62%" cy="68%" r="65%" gradientUnits="objectBoundingBox">
+      <stop offset="0%"   stop-color="#3a6818"/>
+      <stop offset="100%" stop-color="#040c00"/>
+    </radialGradient>
+    <radialGradient id="highlight-rg" cx="40%" cy="35%" r="60%">
+      <stop offset="0%"   stop-color="#ffffff"/>
+      <stop offset="40%"  stop-color="#d8ff70"/>
+      <stop offset="100%" stop-color="#90d020" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="highlight-blur">
+      <feGaussianBlur stdDeviation="0.9"/>
+    </filter>
+  </defs>
+  <circle cx="256" cy="272" r="230" fill="#071a08"/>
+  <circle cx="256" cy="264" r="200" fill="url(#ring-outer)"/>
+  <circle cx="256" cy="256" r="175" fill="#081808"/>
+  <circle cx="256" cy="256" r="162" fill="url(#ring-mid)"/>
+  <circle cx="256" cy="256" r="138" fill="#071208"/>
+  <circle cx="256" cy="256" r="126" fill="url(#ring-inner)"/>
+  <circle cx="256" cy="256" r="108" fill="#061008"/>
+  <circle cx="256" cy="256" r="96" fill="url(#cone)"/>
+  <circle cx="256" cy="256" r="72" fill="url(#dustcap)" stroke="rgba(0,0,0,0.8)" stroke-width="8"/>
+  <circle cx="278" cy="226" r="14" fill="url(#highlight-rg)" filter="url(#highlight-blur)"/>
+  <circle cx="138" cy="155" r="13" fill="#040c02"/>
+  <circle cx="137" cy="154" r="13" fill="url(#screw)"/>
+  <line x1="131" y1="154" x2="143" y2="154" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="137" y1="148" x2="137" y2="160" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="375" cy="155" r="13" fill="#040c02"/>
+  <circle cx="374" cy="154" r="13" fill="url(#screw)"/>
+  <line x1="368" y1="154" x2="380" y2="154" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="374" y1="148" x2="374" y2="160" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="138" cy="358" r="13" fill="#040c02"/>
+  <circle cx="137" cy="357" r="13" fill="url(#screw)"/>
+  <line x1="131" y1="357" x2="143" y2="357" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="137" y1="351" x2="137" y2="363" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="375" cy="358" r="13" fill="#040c02"/>
+  <circle cx="374" cy="357" r="13" fill="url(#screw)"/>
+  <line x1="368" y1="357" x2="380" y2="357" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="374" y1="351" x2="374" y2="363" stroke="rgba(0,0,0,0.25)" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/app.css
+++ b/src/app.css
@@ -136,12 +136,27 @@ button {
 	letter-spacing: -0.02em;
 }
 
-.app-version {
+.app-footer {
 	text-align: center;
 	font-size: 0.75rem;
+	margin-top: 16px;
+}
+
+.app-version {
 	color: var(--text-muted);
 	opacity: 0.5;
-	margin-top: 16px;
+}
+
+.update-badge {
+	display: inline-flex;
+	align-items: center;
+	margin-left: 6px;
+	color: var(--accent);
+	vertical-align: middle;
+}
+
+.update-badge:hover {
+	opacity: 0.7;
 }
 
 .empty-state {

--- a/src/components/InstanceList.svelte
+++ b/src/components/InstanceList.svelte
@@ -8,6 +8,15 @@
 	let showAddForm = $state(false);
 	let update = $state<ReleaseInfo | null>(null);
 
+	const hostedPwa = location.hostname === 'pwa.odio.love';
+	const updateTooltip = $derived(
+		update
+			? hostedPwa
+				? `v${update.version} available — this PWA updates itself automatically, click for release notes`
+				: `v${update.version} available — click for release notes`
+			: '',
+	);
+
 	onMount(() => {
 		appState.connectAll();
 		function onVisible() {
@@ -66,8 +75,8 @@
 				href={update.url}
 				target="_blank"
 				rel="noopener noreferrer"
-				title="v{update.version} available — click for release notes"
-				aria-label="v{update.version} available — click for release notes"
+				title={updateTooltip}
+				aria-label={updateTooltip}
 			>
 				<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
 					<line x1="12" y1="19" x2="12" y2="5" />

--- a/src/components/InstanceList.svelte
+++ b/src/components/InstanceList.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { appState } from '../lib/state.svelte';
+	import { fetchLatestRelease, type ReleaseInfo } from '../lib/github';
 	import InstanceCard from './InstanceCard.svelte';
 	import AddInstanceForm from './AddInstanceForm.svelte';
 
 	let showAddForm = $state(false);
+	let update = $state<ReleaseInfo | null>(null);
 
 	onMount(() => {
 		appState.connectAll();
@@ -12,6 +14,11 @@
 			if (document.visibilityState === 'visible') appState.probeAll();
 		}
 		document.addEventListener('visibilitychange', onVisible);
+
+		fetchLatestRelease(__APP_VERSION__).then((latest) => {
+			if (latest) update = latest;
+		});
+
 		return () => {
 			appState.disconnectAll();
 			document.removeEventListener('visibilitychange', onVisible);
@@ -51,5 +58,22 @@
 		{/if}
 	</section>
 
-	<p class="app-version">v{__APP_VERSION__}</p>
+	<footer class="app-footer">
+		<span class="app-version">v{__APP_VERSION__}</span>
+		{#if update}
+			<a
+				class="update-badge"
+				href={update.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				title="v{update.version} available — click for release notes"
+				aria-label="v{update.version} available — click for release notes"
+			>
+				<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+					<line x1="12" y1="19" x2="12" y2="5" />
+					<polyline points="5 12 12 5 19 12" />
+				</svg>
+			</a>
+		{/if}
+	</footer>
 </main>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,97 @@
+const REPO = 'b0bbywan/odio-pwa';
+const CACHE_KEY = 'odio-latest-release';
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+export type ReleaseInfo = {
+	version: string;
+	url: string;
+};
+
+type CacheEntry = {
+	checkedAt: number;
+	latest: ReleaseInfo | null;
+};
+
+export async function fetchLatestRelease(current: string): Promise<ReleaseInfo | null> {
+	const cached = readCache(current);
+	if (cached) return cached.latest;
+
+	try {
+		const res = await fetch(
+			`https://api.github.com/repos/${REPO}/releases/latest`,
+			{ headers: { Accept: 'application/vnd.github+json' } },
+		);
+		if (!res.ok) return null;
+		const data = (await res.json()) as { tag_name: string; html_url: string };
+		const latest: ReleaseInfo = {
+			version: data.tag_name.replace(/^v/, ''),
+			url: data.html_url,
+		};
+		if (isNewerVersion(latest.version, current)) {
+			writeCache({ checkedAt: Date.now(), latest });
+			return latest;
+		}
+		writeCache({ checkedAt: Date.now(), latest: null });
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function readCache(current: string): CacheEntry | null {
+	try {
+		const raw = localStorage.getItem(CACHE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as CacheEntry;
+		if (Date.now() - parsed.checkedAt > CACHE_TTL_MS) {
+			localStorage.removeItem(CACHE_KEY);
+			return null;
+		}
+		if (parsed.latest && !isNewerVersion(parsed.latest.version, current)) {
+			// We've caught up with the cached "latest" (app was updated).
+			// Drop the stale pointer but preserve checkedAt so we don't refetch until TTL.
+			const cleaned: CacheEntry = { checkedAt: parsed.checkedAt, latest: null };
+			writeCache(cleaned);
+			return cleaned;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(entry: CacheEntry): void {
+	try {
+		localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+	} catch {
+		// quota exceeded or disabled — ignore
+	}
+}
+
+// semver-ish compare: returns true if `latest` is newer than `current`.
+// Handles MAJOR.MINOR.PATCH with optional -prerelease suffix (rc1, beta2, etc.)
+export function isNewerVersion(latest: string, current: string): boolean {
+	const l = parseVersion(latest);
+	const c = parseVersion(current);
+	if (!l || !c) return false;
+	if (l.major !== c.major) return l.major > c.major;
+	if (l.minor !== c.minor) return l.minor > c.minor;
+	if (l.patch !== c.patch) return l.patch > c.patch;
+	if (l.pre === c.pre) return false;
+	if (!l.pre) return true;
+	if (!c.pre) return false;
+	return l.pre > c.pre;
+}
+
+type ParsedVersion = { major: number; minor: number; patch: number; pre: string | null };
+
+function parseVersion(v: string): ParsedVersion | null {
+	const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+	if (!m) return null;
+	return {
+		major: Number(m[1]),
+		minor: Number(m[2]),
+		patch: Number(m[3]),
+		pre: m[4] ?? null,
+	};
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,6 @@
 const REPO = 'b0bbywan/odio-pwa';
-const CACHE_KEY = 'odio-latest-release';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const INCLUDE_PRERELEASE_KEY = 'odio-include-prereleases';
 
 export type ReleaseInfo = {
 	version: string;
@@ -12,21 +12,43 @@ type CacheEntry = {
 	latest: ReleaseInfo | null;
 };
 
+// Toggle via devtools: `localStorage.setItem('odio-include-prereleases', 'true')`
+function includePrerelease(): boolean {
+	try {
+		return localStorage.getItem(INCLUDE_PRERELEASE_KEY) === 'true';
+	} catch {
+		return false;
+	}
+}
+
+function cacheKey(): string {
+	return includePrerelease() ? 'odio-latest-release-pre' : 'odio-latest-release';
+}
+
+async function fetchFromApi(): Promise<ReleaseInfo | null> {
+	const url = includePrerelease()
+		? `https://api.github.com/repos/${REPO}/releases?per_page=1`
+		: `https://api.github.com/repos/${REPO}/releases/latest`;
+	const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
+	if (!res.ok) return null;
+	const data = (await res.json()) as
+		| { tag_name: string; html_url: string }
+		| Array<{ tag_name: string; html_url: string }>;
+	const entry = Array.isArray(data) ? data[0] : data;
+	if (!entry) return null;
+	return {
+		version: entry.tag_name.replace(/^v/, ''),
+		url: entry.html_url,
+	};
+}
+
 export async function fetchLatestRelease(current: string): Promise<ReleaseInfo | null> {
 	const cached = readCache(current);
 	if (cached) return cached.latest;
 
 	try {
-		const res = await fetch(
-			`https://api.github.com/repos/${REPO}/releases/latest`,
-			{ headers: { Accept: 'application/vnd.github+json' } },
-		);
-		if (!res.ok) return null;
-		const data = (await res.json()) as { tag_name: string; html_url: string };
-		const latest: ReleaseInfo = {
-			version: data.tag_name.replace(/^v/, ''),
-			url: data.html_url,
-		};
+		const latest = await fetchFromApi();
+		if (!latest) return null;
 		if (isNewerVersion(latest.version, current)) {
 			writeCache({ checkedAt: Date.now(), latest });
 			return latest;
@@ -39,12 +61,13 @@ export async function fetchLatestRelease(current: string): Promise<ReleaseInfo |
 }
 
 function readCache(current: string): CacheEntry | null {
+	const key = cacheKey();
 	try {
-		const raw = localStorage.getItem(CACHE_KEY);
+		const raw = localStorage.getItem(key);
 		if (!raw) return null;
 		const parsed = JSON.parse(raw) as CacheEntry;
 		if (Date.now() - parsed.checkedAt > CACHE_TTL_MS) {
-			localStorage.removeItem(CACHE_KEY);
+			localStorage.removeItem(key);
 			return null;
 		}
 		if (parsed.latest && !isNewerVersion(parsed.latest.version, current)) {
@@ -62,7 +85,7 @@ function readCache(current: string): CacheEntry | null {
 
 function writeCache(entry: CacheEntry): void {
 	try {
-		localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+		localStorage.setItem(cacheKey(), JSON.stringify(entry));
 	} catch {
 		// quota exceeded or disabled — ignore
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { VitePWA } from 'vite-plugin-pwa';
-import { version } from './package.json';
+import { version as pkgVersion } from './package.json';
+
+const appVersion = process.env.APP_VERSION ?? pkgVersion;
 
 export default defineConfig({
 	define: {
-		__APP_VERSION__: JSON.stringify(version),
+		__APP_VERSION__: JSON.stringify(appVersion),
 	},
 	plugins: [
 		svelte(),


### PR DESCRIPTION
On `v*` tag push, CI builds dist/, attaches a zip to the GitHub Release and pushes a multi-arch nginx:alpine image to GHCR (native amd64 + arm64 runners, no QEMU). nginx is configured with SPA fallback and PWA-aware cache headers. The build reads APP_VERSION from the tag so the UI version tracks the release without requiring a package.json bump for every rc.