### PR TITLE
feat: open instance from URL params and prompt to save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run check
+
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Manage multiple odio-api endpoints from a single interface — add instances man
 ## Features
 
 - **Instance management** — add, edit, delete odio-api instances (IP/hostname + port), persisted in localStorage
+- **Deep linking** — open an instance directly via `#/i/<host>/<port>?label=<name>` (port and label optional). First-time visits stay in-memory only and prompt to save on exit, so QR codes and shared links don't silently pollute the user's list
 - **Real-time status** — live updates via SSE (`/events`), up to 6 concurrent connections; additional instances fall back to HTTP polling every 30 s
 - **Smart reconnect** — exponential backoff on connection loss (1 s → 30 s cap); gives up after 90 s of consecutive failures
 - **Power event handling** — reboot shows a waiting screen and auto-reloads when the server comes back; poweroff offers to wait or go back to the list immediately; servers without SSE support are detected automatically and use polling only
@@ -82,20 +83,20 @@ npm run check
 ```
 src/
 ├── lib/
-│   ├── types.ts            # OdioServerInfo, OdioInstance, AppView
+│   ├── types.ts            # OdioServerInfo, OdioInstance, PowerEvent
 │   ├── api.ts              # probeInstance(), getInstanceUiUrl()
 │   ├── sse.ts              # connectSSE() — thin EventSource wrapper
 │   ├── connection.ts       # createConnection() — backoff, give-up, SSE/polling
-│   └── state.svelte.ts     # Reactive state (Svelte 5 runes, class pattern)
+│   └── state.svelte.ts     # Reactive state (Svelte 5 runes), instancePath() helper
 ├── components/
 │   ├── InstanceList.svelte    # Discovery screen with card grid
 │   ├── InstanceCard.svelte    # Status indicator, server info, actions
 │   ├── AddInstanceForm.svelte # Add/edit form (host, port, label)
-│   ├── InstanceTopBar.svelte  # Navigation bar with instance switcher
+│   ├── InstanceTopBar.svelte  # Navigation bar with instance switcher + Save button
 │   ├── PowerScreen.svelte     # Full-screen reboot/poweroff state display
-│   ├── InstanceView.svelte    # Iframe embed, power event orchestration
+│   ├── InstanceView.svelte    # Iframe embed, power event orchestration, save prompt
 │   └── ReloadPrompt.svelte    # PWA update toast
-├── App.svelte               # View routing (list ↔ instance)
+├── App.svelte               # Hash routing (svelte-spa-router): / and /i/:host/:port?
 ├── app.css                  # Global styles, dark theme
 └── main.ts                  # App bootstrap
 ```
@@ -103,6 +104,7 @@ src/
 ### Tech stack
 
 - [Svelte 5](https://svelte.dev/) with runes (`$state`, `$derived`, `$effect`)
+- [svelte-spa-router](https://github.com/ItalyPaleAle/svelte-spa-router) for hash-based deep linking
 - [Vite](https://vite.dev/)
 - [vite-plugin-pwa](https://vite-pwa-org.netlify.app/) with Workbox
 - [Vitest](https://vitest.dev/) + [@testing-library/svelte](https://testing-library.com/docs/svelte-testing-library/intro) for unit and component tests
@@ -129,6 +131,18 @@ The production build outputs to `dist/`. The preview server serves it at `http:/
 3. The app probes `/server` to check if the instance is online
 4. Tap **Connect** on an online instance to load its UI in an iframe
 5. Use the **switch dropdown** in the top bar to jump between instances
+
+### Deep links
+
+You can also open an instance straight from a URL:
+
+```
+https://pwa.odio.love/#/i/<host>[/<port>][?label=<name>]
+```
+
+- `host` is required, `port` defaults to `8018`, `label` is optional
+- Examples: `#/i/192.168.1.10`, `#/i/odio.local/9000?label=Living%20Room`
+- The instance is held in-memory only; a **Save** button appears in the top bar to persist it, and leaving without saving (in-app or browser back) prompts to Save / Don't save / Cancel
 
 ## Technical notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "odio-pwa",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odio-pwa",
-      "version": "0.3.3",
+      "version": "0.4.0",
+      "dependencies": {
+        "svelte-spa-router": "^5.1.0"
+      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2267,7 +2270,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2278,7 +2280,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2289,7 +2290,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2310,24 +2310,49 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2349,19 +2374,41 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -2752,34 +2799,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ejs": "^3.1.6",
-        "json5": "^2.2.0",
-        "magic-string": "^0.25.0",
-        "string.prototype.matchall": "^4.0.6"
-      }
-    },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -2921,6 +2944,22 @@
         "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
       }
     },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
@@ -2957,7 +2996,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2981,7 +3019,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
@@ -3140,7 +3177,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3203,7 +3239,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3334,7 +3369,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3416,16 +3450,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3470,15 +3504,15 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3570,7 +3604,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3874,10 +3907,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
-      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
-      "dev": true,
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
+      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -3939,9 +3971,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4137,14 +4169,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
       "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -4165,6 +4195,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
     "node_modules/expect-type": {
@@ -4227,9 +4270,9 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4903,7 +4946,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -5327,14 +5369,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -5375,7 +5409,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5670,9 +5703,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5693,9 +5726,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5858,6 +5891,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -5986,15 +6028,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -6064,9 +6106,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6166,14 +6208,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6295,14 +6337,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -6487,7 +6521,6 @@
       "version": "5.53.7",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.7.tgz",
       "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -6533,6 +6566,21 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-spa-router": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-spa-router/-/svelte-spa-router-5.1.0.tgz",
+      "integrity": "sha512-YGtXOF+advJnQBvS4mvRnHVUF0qpSI2pUrSxidz4s7X9x80IKEgYzupx6j46gZcIcN3BYjmuLUbsgQv1S5bZzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "regexparam": "2.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ItalyPaleAle"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -6802,9 +6850,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6928,9 +6976,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7296,30 +7344,30 @@
       }
     },
     "node_modules/workbox-background-sync": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
-      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
-      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-build": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
-      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7327,135 +7375,42 @@
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
-        "@rollup/plugin-babel": "^5.2.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^2.4.1",
-        "@rollup/plugin-terser": "^0.4.3",
-        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
         "ajv": "^8.6.0",
         "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^11.0.1",
-        "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
-        "rollup": "^2.79.2",
+        "rollup": "^4.53.3",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "7.4.0",
-        "workbox-broadcast-update": "7.4.0",
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-google-analytics": "7.4.0",
-        "workbox-navigation-preload": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-range-requests": "7.4.0",
-        "workbox-recipes": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0",
-        "workbox-streams": "7.4.0",
-        "workbox-sw": "7.4.0",
-        "workbox-window": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
-      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
@@ -7471,157 +7426,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/workbox-cacheable-response": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
-      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
-      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
-      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
-      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-background-sync": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
-      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
-      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
-      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
-      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
-      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
-      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
-      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
-      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-window": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
-      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/xml-name-validator": {
@@ -7652,7 +7591,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.0.18",
     "workbox-window": "^7.4.0"
+  },
+  "dependencies": {
+    "svelte-spa-router": "^5.1.0"
   }
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,24 @@
+# odio-pwa
+
+> Progressive Web App for discovering and controlling odio-api instances on your local network. Manage multiple odio nodes from a single installable interface, with real-time status and one-tap switching.
+
+Built in Svelte 5 with Vite and vite-plugin-pwa. Probes each instance via `/server`, subscribes to live updates via Server-Sent Events (`/events`) with HTTP polling fallback (30 s), and embeds each instance's `/ui` in a full-screen iframe. Multi-arch Docker image published to GHCR for self-hosting.
+
+## What it does
+- Add/edit/delete odio-api instances (IP/hostname + port), persisted in localStorage
+- Real-time status via SSE (up to 6 concurrent), polling fallback for older API versions
+- Smart reconnect with exponential backoff (1 s to 30 s, gives up after 90 s)
+- Power event handling: reboot waits and auto-reloads, poweroff offers wait or back-to-list
+- Quick-switch dropdown to jump between online instances
+- In-app diagnostics for HTTPS/mixed-content edge cases (Firefox, Safari, Chrome 142+)
+
+## Key pages
+- [Live app](https://pwa.odio.love/): hosted instance, installable as a PWA
+- [GitHub repo](https://github.com/b0bbywan/odio-pwa): source, releases, issues
+- [Documentation](https://docs.odio.love/guides/pwa/): full guide, multi-node setup, self-hosting, HTTPS notes
+- [Docker image](https://github.com/b0bbywan/odio-pwa/pkgs/container/odio-pwa): `ghcr.io/b0bbywan/odio-pwa:latest` (linux/amd64, linux/arm64)
+- [odio.love](https://odio.love/): main project site
+- [go-odio-api](https://github.com/b0bbywan/go-odio-api): the API the PWA controls
+
+## Maintainer
+- [b0bbywan](https://github.com/b0bbywan): creator of the odio stack. Senior R&D engineer based in Lille, France, 15 years in tech startups (gaming, SaaS, robotics, IoT).

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import Router from 'svelte-spa-router';
 	import { appState } from './lib/state.svelte';
 	import InstanceList from './components/InstanceList.svelte';
 	import InstanceView from './components/InstanceView.svelte';
 	import ReloadPrompt from './components/ReloadPrompt.svelte';
 
+	const routes = {
+		'/': InstanceList,
+		'/i/:host/:port?': InstanceView,
+		'*': InstanceList,
+	};
+
+	// Probes run app-wide so the TopBar switcher works on F5 into an instance,
+	// not only when the list view has been visited. Idempotent connectAll won't
+	// trample InstanceView's power-callback connection. Per-connection
+	// visibilitychange handlers in lib/connection.ts cover the wake-on-resume
+	// case, so no app-level handler here.
 	onMount(() => {
-		function onPopState() {
-			if (appState.currentView === 'instance') appState.goToList();
-		}
-		window.addEventListener('popstate', onPopState);
-		return () => window.removeEventListener('popstate', onPopState);
+		appState.connectAll();
+		return () => appState.disconnectAll();
 	});
 </script>
 
-{#if appState.currentView === 'list'}
-	<InstanceList />
-{:else if appState.currentView === 'instance'}
-	<InstanceView />
-{/if}
-
+<Router {routes} />
 <ReloadPrompt />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import Router from 'svelte-spa-router';
+	import { useRegisterSW } from 'virtual:pwa-register/svelte';
 	import { appState } from './lib/state.svelte';
 	import InstanceList from './components/InstanceList.svelte';
 	import InstanceView from './components/InstanceView.svelte';
@@ -11,6 +12,17 @@
 		'/i/:host/:port?': InstanceView,
 		'*': InstanceList,
 	};
+
+	const { offlineReady, needRefresh, updateServiceWorker } = useRegisterSW({
+		onRegisteredSW(_swUrl: string, registration: ServiceWorkerRegistration | undefined) {
+			if (registration) {
+				setInterval(() => registration.update(), 60 * 60 * 1000);
+			}
+		},
+		onRegisterError(error: unknown) {
+			console.error('SW registration error:', error);
+		},
+	});
 
 	// Probes run app-wide so the TopBar switcher works on F5 into an instance,
 	// not only when the list view has been visited. Idempotent connectAll won't
@@ -24,4 +36,4 @@
 </script>
 
 <Router {routes} />
-<ReloadPrompt />
+<ReloadPrompt {offlineReady} {needRefresh} {updateServiceWorker} />

--- a/src/app.css
+++ b/src/app.css
@@ -602,7 +602,7 @@ button {
 
 /* Power event screen */
 
-.power-screen {
+.status-screen {
 	flex: 1;
 	display: flex;
 	flex-direction: column;
@@ -614,23 +614,23 @@ button {
 	padding: 24px;
 }
 
-.power-screen-icon {
+.status-screen-icon {
 	color: var(--accent);
 	margin-bottom: 4px;
 }
 
-.power-screen-title {
+.status-screen-title {
 	font-size: 1.2rem;
 	font-weight: 700;
 	color: var(--text-primary);
 }
 
-.power-screen-body {
+.status-screen-body {
 	font-size: 0.9rem;
 	color: var(--text-secondary);
 }
 
-.power-screen-actions {
+.status-screen-actions {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;

--- a/src/app.css
+++ b/src/app.css
@@ -502,6 +502,67 @@ button {
 	border: none;
 }
 
+.btn-save-instance {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: var(--accent);
+	color: #fff;
+	padding: 6px 12px;
+	border-radius: var(--radius);
+	font-weight: 600;
+	font-size: 0.85rem;
+	transition: background 0.2s;
+}
+
+.btn-save-instance:hover {
+	background: var(--accent-hover);
+}
+
+.save-prompt-backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	z-index: 20;
+}
+
+.save-prompt {
+	position: fixed;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	background: var(--bg-secondary);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	padding: 20px;
+	width: min(360px, calc(100vw - 32px));
+	z-index: 21;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.save-prompt h3 {
+	font-size: 1.05rem;
+	margin-bottom: 8px;
+}
+
+.save-prompt p {
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+	margin-bottom: 16px;
+	line-height: 1.4;
+}
+
+.save-prompt-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.save-prompt-actions .btn-primary {
+	flex: 1;
+	min-width: 90px;
+}
+
 /* PWA Toast */
 
 .pwa-toast {

--- a/src/components/ConnectionStatusScreen.svelte
+++ b/src/components/ConnectionStatusScreen.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	let {
+		status,
+		displayName,
+		host,
+		port,
+		onback,
+	}: {
+		status: 'probing' | 'unknown' | 'offline' | 'blocked';
+		displayName: string;
+		host: string;
+		port: number;
+		onback: () => void;
+	} = $props();
+
+	const lanDocsHref = 'https://docs.odio.love/guides/pwa/#lan-access';
+	const probing = $derived(status === 'probing' || status === 'unknown');
+</script>
+
+<div class="status-screen" role="status">
+	{#if probing}
+		<svg class="status-screen-icon spin" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+			<polyline points="23 4 23 10 17 10" />
+			<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+		</svg>
+		<h2 class="status-screen-title">Connecting to {displayName}</h2>
+		<p class="status-screen-body">{host}:{port}</p>
+		<div class="status-screen-actions">
+			<button class="btn-secondary" onclick={onback}>Back to list</button>
+		</div>
+	{:else if status === 'offline'}
+		<svg class="status-screen-icon" style="color: var(--danger)" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+			<circle cx="12" cy="12" r="10" />
+			<line x1="12" y1="8" x2="12" y2="12" />
+			<line x1="12" y1="16" x2="12.01" y2="16" />
+		</svg>
+		<h2 class="status-screen-title">Server unreachable</h2>
+		<p class="status-screen-body">{host}:{port} did not respond.</p>
+		<div class="status-screen-actions">
+			<button class="btn-secondary" onclick={onback}>Back to list</button>
+		</div>
+	{:else if status === 'blocked'}
+		<svg class="status-screen-icon" style="color: var(--warning)" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+			<circle cx="12" cy="12" r="10" />
+			<line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
+		</svg>
+		<h2 class="status-screen-title">Browser blocked the request</h2>
+		<p class="status-screen-body">
+			HTTPS pages cannot reach {host}:{port} on plain HTTP. See
+			<a href={lanDocsHref} target="_blank" rel="noopener noreferrer">mixed content</a>.
+		</p>
+		<div class="status-screen-actions">
+			<button class="btn-secondary" onclick={onback}>Back to list</button>
+		</div>
+	{/if}
+</div>

--- a/src/components/ConnectionStatusScreen.test.ts
+++ b/src/components/ConnectionStatusScreen.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ConnectionStatusScreen from './ConnectionStatusScreen.svelte';
+
+const noop = () => {};
+
+function renderScreen(overrides: Partial<{
+	status: 'probing' | 'unknown' | 'offline' | 'blocked';
+	displayName: string;
+	host: string;
+	port: number;
+	onback: () => void;
+}> = {}) {
+	return render(ConnectionStatusScreen, {
+		status: 'probing',
+		displayName: 'Pi',
+		host: '192.168.1.10',
+		port: 8018,
+		onback: noop,
+		...overrides,
+	});
+}
+
+// ── probing ───────────────────────────────────────────────────────────────────
+
+describe('ConnectionStatusScreen — probing', () => {
+	test('shows "Connecting to {displayName}" with host:port', () => {
+		renderScreen({ status: 'probing', displayName: 'Living Room', host: 'odio.local', port: 9000 });
+		expect(screen.getByText(/Connecting to Living Room/)).toBeInTheDocument();
+		expect(screen.getByText('odio.local:9000')).toBeInTheDocument();
+	});
+
+	test('"unknown" status renders the same Connecting view', () => {
+		renderScreen({ status: 'unknown' });
+		expect(screen.getByText(/Connecting to/)).toBeInTheDocument();
+	});
+
+	test('back button calls onback', async () => {
+		const onback = vi.fn();
+		renderScreen({ status: 'probing', onback });
+		await fireEvent.click(screen.getByRole('button', { name: /back to list/i }));
+		expect(onback).toHaveBeenCalledOnce();
+	});
+});
+
+// ── offline ───────────────────────────────────────────────────────────────────
+
+describe('ConnectionStatusScreen — offline', () => {
+	test('shows "Server unreachable" with host:port', () => {
+		renderScreen({ status: 'offline', host: '192.168.1.99', port: 8018 });
+		expect(screen.getByText('Server unreachable')).toBeInTheDocument();
+		expect(screen.getByText(/192.168.1.99:8018 did not respond/)).toBeInTheDocument();
+	});
+
+	test('back button calls onback', async () => {
+		const onback = vi.fn();
+		renderScreen({ status: 'offline', onback });
+		await fireEvent.click(screen.getByRole('button', { name: /back to list/i }));
+		expect(onback).toHaveBeenCalledOnce();
+	});
+});
+
+// ── blocked ───────────────────────────────────────────────────────────────────
+
+describe('ConnectionStatusScreen — blocked', () => {
+	test('shows "Browser blocked" with a link to the mixed-content guide', () => {
+		renderScreen({ status: 'blocked', host: '192.168.1.10', port: 8018 });
+		expect(screen.getByText('Browser blocked the request')).toBeInTheDocument();
+		const link = screen.getByRole('link', { name: /mixed content/i });
+		expect(link).toHaveAttribute('href', expect.stringContaining('docs.odio.love'));
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+	});
+
+	test('back button calls onback', async () => {
+		const onback = vi.fn();
+		renderScreen({ status: 'blocked', onback });
+		await fireEvent.click(screen.getByRole('button', { name: /back to list/i }));
+		expect(onback).toHaveBeenCalledOnce();
+	});
+});

--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -79,7 +79,7 @@
 			<button
 				class="btn-primary"
 				onclick={() => appState.openInstance(instance.id)}
-				disabled={instance.status !== 'online'}
+				disabled={instance.status !== 'online' && instance.status !== 'cors'}
 			>
 				Connect
 			</button>

--- a/src/components/InstanceCard.test.ts
+++ b/src/components/InstanceCard.test.ts
@@ -131,6 +131,16 @@ describe('InstanceCard — Connect button', () => {
 		expect(screen.getByRole('button', { name: 'Connect' })).toBeDisabled();
 	});
 
+	test('enabled when cors — iframe loads even without API CORS headers', () => {
+		render(InstanceCard, { instance: { ...base, status: 'cors' } });
+		expect(screen.getByRole('button', { name: 'Connect' })).not.toBeDisabled();
+	});
+
+	test('disabled when blocked — mixed-content stops the iframe too', () => {
+		render(InstanceCard, { instance: { ...base, status: 'blocked' } });
+		expect(screen.getByRole('button', { name: 'Connect' })).toBeDisabled();
+	});
+
 	test('click calls appState.openInstance with the instance id', async () => {
 		render(InstanceCard, { instance: base });
 		await fireEvent.click(screen.getByRole('button', { name: 'Connect' }));

--- a/src/components/InstanceList.svelte
+++ b/src/components/InstanceList.svelte
@@ -26,22 +26,10 @@
 	);
 
 	onMount(() => {
-		appState.connectAll();
-		function onVisible() {
-			if (document.visibilityState === 'visible') appState.probeAll();
-		}
-		document.addEventListener('visibilitychange', onVisible);
-
 		fetchLatestRelease(__APP_VERSION__).then((latest) => {
 			if (latest) update = latest;
 		});
-
 		unsupported = detectUnsupportedDesktop();
-
-		return () => {
-			appState.disconnectAll();
-			document.removeEventListener('visibilitychange', onVisible);
-		};
 	});
 </script>
 

--- a/src/components/InstanceList.test.ts
+++ b/src/components/InstanceList.test.ts
@@ -52,20 +52,8 @@ describe('InstanceList — empty state', () => {
 	});
 });
 
-// ── lifecycle ─────────────────────────────────────────────────────────────────
-
-describe('InstanceList — lifecycle', () => {
-	test('calls connectAll on mount', () => {
-		render(InstanceList);
-		expect(appState.connectAll).toHaveBeenCalledOnce();
-	});
-
-	test('calls disconnectAll on unmount', () => {
-		const { unmount } = render(InstanceList);
-		unmount();
-		expect(appState.disconnectAll).toHaveBeenCalledOnce();
-	});
-});
+// Lifecycle (connectAll/disconnectAll) lives in App.svelte now so probes keep
+// running when the user is on the instance route directly (e.g. after F5).
 
 // ── toolbar ───────────────────────────────────────────────────────────────────
 

--- a/src/components/InstanceTopBar.svelte
+++ b/src/components/InstanceTopBar.svelte
@@ -51,7 +51,7 @@
 		</button>
 	{/if}
 
-	{#if appState.onlineInstances.length > 1}
+	{#if appState.connectableInstances.length > 1}
 		<div class="switcher-wrapper">
 			<button
 				class="btn-switch"
@@ -67,7 +67,7 @@
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div class="switcher-backdrop" onclick={() => (showSwitcher = false)}></div>
 				<div class="switcher-dropdown">
-					{#each appState.onlineInstances as other (other.id)}
+					{#each appState.connectableInstances as other (other.id)}
 						{#if other.id !== currentId}
 							<button onclick={() => handleSwitch(other.id)}>
 								{other.label ||

--- a/src/components/InstanceTopBar.svelte
+++ b/src/components/InstanceTopBar.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
+	import { push } from 'svelte-spa-router';
 	import { appState } from '../lib/state.svelte';
 
 	let {
 		displayName,
 		currentId,
 		onswitchto,
+		onback,
+		transient = false,
+		onsave,
 	}: {
 		displayName: string;
 		currentId: string;
 		onswitchto: (id: string) => void;
+		onback?: () => void;
+		transient?: boolean;
+		onsave?: () => void;
 	} = $props();
 
 	let showSwitcher = $state(false);
@@ -17,16 +24,32 @@
 		showSwitcher = false;
 		onswitchto(id);
 	}
+
+	function handleBack() {
+		if (onback) onback();
+		else push('/');
+	}
 </script>
 
 <nav class="top-bar">
-	<button class="btn-icon" onclick={() => { history.back(); appState.goToList(); }} title="Back to list">
+	<button class="btn-icon" onclick={handleBack} title="Back to list">
 		<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
 			<polyline points="15 18 9 12 15 6" />
 		</svg>
 	</button>
 
 	<span class="current-name">{displayName}</span>
+
+	{#if transient && onsave}
+		<button class="btn-save-instance" onclick={onsave} title="Save this instance">
+			<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+				<polyline points="17 21 17 13 7 13 7 21" />
+				<polyline points="7 3 7 8 15 8" />
+			</svg>
+			<span>Save</span>
+		</button>
+	{/if}
 
 	{#if appState.onlineInstances.length > 1}
 		<div class="switcher-wrapper">

--- a/src/components/InstanceTopBar.test.ts
+++ b/src/components/InstanceTopBar.test.ts
@@ -6,13 +6,15 @@ import type { OdioInstance } from '../lib/types';
 // Mock appState before importing the component so the component picks up the mock.
 vi.mock('../lib/state.svelte', () => ({
 	appState: {
-		goToList: vi.fn(),
 		onlineInstances: [] as OdioInstance[],
 	},
 }));
 
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
+
 import InstanceTopBar from './InstanceTopBar.svelte';
 import { appState } from '../lib/state.svelte';
+import { push } from 'svelte-spa-router';
 
 const inst = (id: string, label: string): OdioInstance => ({
 	id,
@@ -35,18 +37,57 @@ describe('InstanceTopBar — display', () => {
 		expect(screen.getByText('My Pi')).toBeInTheDocument();
 	});
 
-	test('back button calls appState.goToList', async () => {
+	test('back button routes to / when no onback is provided', async () => {
 		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn() });
 		await fireEvent.click(screen.getByTitle('Back to list'));
-		expect(appState.goToList).toHaveBeenCalledOnce();
+		expect(push).toHaveBeenCalledWith('/');
+	});
+});
+
+// ── onback override ───────────────────────────────────────────────────────────
+
+describe('InstanceTopBar — onback override', () => {
+	test('back button calls onback when provided, not push', async () => {
+		const onback = vi.fn();
+		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn(), onback });
+		await fireEvent.click(screen.getByTitle('Back to list'));
+		expect(onback).toHaveBeenCalledOnce();
+		expect(push).not.toHaveBeenCalled();
+	});
+});
+
+// ── transient save button ─────────────────────────────────────────────────────
+
+describe('InstanceTopBar — save button', () => {
+	test('hidden by default', () => {
+		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn() });
+		expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
 	});
 
-	test('back button calls history.back()', async () => {
-		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
-		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn() });
-		await fireEvent.click(screen.getByTitle('Back to list'));
-		expect(back).toHaveBeenCalledOnce();
-		back.mockRestore();
+	test('hidden when transient is true but onsave is missing', () => {
+		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn(), transient: true });
+		expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+	});
+
+	test('hidden when onsave is provided but transient is false', () => {
+		render(InstanceTopBar, { displayName: 'My Pi', currentId: '1', onswitchto: vi.fn(), onsave: vi.fn() });
+		expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+	});
+
+	test('shown when transient and onsave are both provided', () => {
+		render(InstanceTopBar, {
+			displayName: 'My Pi', currentId: '1', onswitchto: vi.fn(), transient: true, onsave: vi.fn(),
+		});
+		expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+	});
+
+	test('clicking it calls onsave', async () => {
+		const onsave = vi.fn();
+		render(InstanceTopBar, {
+			displayName: 'My Pi', currentId: '1', onswitchto: vi.fn(), transient: true, onsave,
+		});
+		await fireEvent.click(screen.getByRole('button', { name: /save/i }));
+		expect(onsave).toHaveBeenCalledOnce();
 	});
 });
 

--- a/src/components/InstanceTopBar.test.ts
+++ b/src/components/InstanceTopBar.test.ts
@@ -6,7 +6,7 @@ import type { OdioInstance } from '../lib/types';
 // Mock appState before importing the component so the component picks up the mock.
 vi.mock('../lib/state.svelte', () => ({
 	appState: {
-		onlineInstances: [] as OdioInstance[],
+		connectableInstances: [] as OdioInstance[],
 	},
 }));
 
@@ -26,7 +26,7 @@ const inst = (id: string, label: string): OdioInstance => ({
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	(appState as { onlineInstances: OdioInstance[] }).onlineInstances = [];
+	(appState as { connectableInstances: OdioInstance[] }).connectableInstances = [];
 });
 
 // ── display ───────────────────────────────────────────────────────────────────
@@ -95,7 +95,7 @@ describe('InstanceTopBar — save button', () => {
 
 describe('InstanceTopBar — switcher hidden', () => {
 	test('no switcher button when there is only one online instance', () => {
-		(appState as { onlineInstances: OdioInstance[] }).onlineInstances = [inst('1', 'Pi 1')];
+		(appState as { connectableInstances: OdioInstance[] }).connectableInstances = [inst('1', 'Pi 1')];
 		render(InstanceTopBar, { displayName: 'Pi 1', currentId: '1', onswitchto: vi.fn() });
 		expect(screen.queryByTitle('Switch instance')).not.toBeInTheDocument();
 	});
@@ -105,7 +105,7 @@ describe('InstanceTopBar — switcher hidden', () => {
 
 describe('InstanceTopBar — switcher with multiple instances', () => {
 	beforeEach(() => {
-		(appState as { onlineInstances: OdioInstance[] }).onlineInstances = [
+		(appState as { connectableInstances: OdioInstance[] }).connectableInstances = [
 			inst('1', 'Pi 1'),
 			inst('2', 'Pi 2'),
 		];

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -34,6 +34,15 @@
 		}
 	});
 
+	// Status can flip to cors after the first probe (e.g. a transient instance
+	// opened via URL params). Drop the keepalive so the give-up timer can't
+	// trigger a misleading poweroff overlay.
+	$effect(() => {
+		if (instance?.status === 'cors' && currentSSEId !== null) {
+			detachSSE();
+		}
+	});
+
 	function handlePowerAction(action: PowerEvent) {
 		powerEvent = action;
 	}
@@ -60,9 +69,13 @@
 
 	function attachSSE(id: string) {
 		if (currentSSEId !== null) appState.disconnectOne(currentSSEId);
-		currentSSEId = id;
+		currentSSEId = null;
 		serverWentOffline = false;
 		waiting = false;
+		// CORS blocks the probe but not the iframe — skip the keepalive so the
+		// give-up timer can't trigger a misleading poweroff overlay.
+		if (instance?.status === 'cors') return;
+		currentSSEId = id;
 		appState.connectOne(id, { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp });
 	}
 

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { push } from 'svelte-spa-router';
+	import { untrack } from 'svelte';
+	import { push, router } from 'svelte-spa-router';
 	import { appState } from '../lib/state.svelte';
 	import { getInstanceUiUrl } from '../lib/api';
 	import type { PowerEvent } from '../lib/types';
 	import InstanceTopBar from './InstanceTopBar.svelte';
 	import PowerScreen from './PowerScreen.svelte';
 	import SavePrompt from './SavePrompt.svelte';
+	import ConnectionStatusScreen from './ConnectionStatusScreen.svelte';
 
 	const DEFAULT_PORT = 8018;
 
@@ -30,13 +31,15 @@
 
 	// Find or transiently add the instance matching the route params. If we
 	// created it and the user neither saved nor discarded, the cleanup removes
-	// it so unsaved hosts don't pile up across route changes.
+	// it so unsaved hosts don't pile up across route changes. The lookup and
+	// the create are untracked so this effect only re-runs when host/port
+	// change, not on every status update of any instance in the array.
 	$effect(() => {
 		if (!host || !Number.isFinite(port)) return;
-		let createdId: string | null = null;
-		if (!appState.findByHostPort(host, port)) {
-			createdId = appState.addInstance(host, port, labelFromUrl, { transient: true });
-		}
+		const createdId = untrack(() => {
+			if (appState.findByHostPort(host, port)) return null;
+			return appState.addInstance(host, port, labelFromUrl, { transient: true });
+		});
 		return () => {
 			if (!createdId) return;
 			if (appState.findById(createdId)?.transient) {
@@ -120,9 +123,12 @@
 		powerEvent = action;
 	}
 
-	// Called by the connection layer after retries are exhausted - treat as poweroff.
+	// Called by the connection layer after retries are exhausted. For an
+	// instance we already reached, treat it as a poweroff so the user can wait.
+	// For a host we never connected to (e.g. a typo'd deep link), the offline
+	// status screen is more honest than "Server is shutting down".
 	function handleGiveUp() {
-		powerEvent = 'poweroff';
+		if (instance?.connectedAt) powerEvent = 'poweroff';
 	}
 
 	function startWaiting() {
@@ -217,10 +223,18 @@
 
 		{#if powerEvent !== null}
 			<PowerScreen event={powerEvent} {waiting} onstartwaiting={startWaiting} ondismiss={dismiss} />
-		{:else}
+		{:else if instance.status === 'online' || instance.status === 'cors'}
 			{#key iframeKey}
 				<iframe src={uiUrl} title="odio-api UI - {displayName}" class="instance-iframe" allow="autoplay; fullscreen"></iframe>
 			{/key}
+		{:else}
+			<ConnectionStatusScreen
+				status={instance.status}
+				{displayName}
+				host={instance.host}
+				port={instance.port}
+				onback={handleBack}
+			/>
 		{/if}
 
 		{#if appState.savePromptVisible && instance.transient}

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -62,7 +62,42 @@
 	let serverWentOffline = $state(false);
 	let waiting = $state(false); // user chose to wait during poweroff
 	let iframeKey = $state(0);
-	let currentSSEId: string | null = null; // plain JS - must not be $state
+
+	function handlePowerAction(action: PowerEvent) {
+		powerEvent = action;
+	}
+
+	// Called by the connection layer after retries are exhausted. For an
+	// instance we already reached, treat it as a poweroff so the user can wait.
+	// For a host we never connected to (e.g. a typo'd deep link), the offline
+	// status screen is more honest than "Server is shutting down".
+	function handleGiveUp() {
+		if (instance?.connectedAt) powerEvent = 'poweroff';
+	}
+
+	const powerCallbacks = { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp };
+
+	// Foreground connection: attach power callbacks while we're on this view,
+	// hand back to the background pool (no callbacks) on unmount or instance
+	// switch. The connection layer skips retries on cors so a missing-headers
+	// server stays idle without spamming probes.
+	let connectedId: string | null = null;
+	$effect(() => {
+		const id = instance?.id;
+		if (!id || id === connectedId) return;
+		connectedId = id;
+		serverWentOffline = false;
+		waiting = false;
+		// A leftover save prompt from a previous instance must not surface here.
+		appState.savePromptVisible = false;
+		appState.connectOne(id, powerCallbacks);
+		return () => {
+			if (connectedId === id) {
+				connectedId = null;
+				appState.connectOne(id);
+			}
+		};
+	});
 
 	// Two-phase detection - reboot always auto-reconnects, poweroff only if user chose to wait.
 	$effect(() => {
@@ -78,65 +113,26 @@
 		}
 	});
 
-	// Status can flip to cors after the first probe (e.g. a transient instance
-	// opened via URL). Drop the keepalive so the give-up timer can't trigger a
-	// misleading poweroff overlay.
-	$effect(() => {
-		if (instance?.status === 'cors' && currentSSEId !== null) {
-			detachSSE();
-		}
-	});
-
-	// Attach/detach SSE in sync with the resolved instance. Re-runs when the
-	// route switches to a different host/port (e.g. via the TopBar switcher).
-	$effect(() => {
-		const id = instance?.id;
-		if (!id) return;
-		if (id === currentSSEId) return;
-		attachSSE(id);
-		return () => {
-			if (currentSSEId === id) detachSSE();
-		};
-	});
-
-	// Trap browser back/forward while a transient instance is open so the user
-	// gets the same Save prompt as the in-app back button. We push a sentinel
-	// entry; popstate then re-arms it and surfaces the dialog instead of
-	// letting the navigation through. On teardown (Save / Don't save / unmount)
-	// we pop the sentinel so the user doesn't have to back through a phantom
-	// history entry to leave.
+	// Trap browser back/forward while a connectable transient instance is open
+	// so the user gets the same Save prompt as the in-app back button. We push
+	// a sentinel entry; popstate then re-arms it and surfaces the dialog
+	// instead of letting the navigation through.
 	$effect(() => {
 		if (!instance?.transient) return;
+		if (instance.status !== 'online' && instance.status !== 'cors') return;
 		history.pushState({ odioGuard: true }, '');
 		function onPopState() {
 			history.pushState({ odioGuard: true }, '');
 			appState.savePromptVisible = true;
 		}
 		window.addEventListener('popstate', onPopState);
-		return () => {
-			window.removeEventListener('popstate', onPopState);
-			if (history.state?.odioGuard) history.back();
-		};
+		return () => window.removeEventListener('popstate', onPopState);
 	});
-
-	function handlePowerAction(action: PowerEvent) {
-		powerEvent = action;
-	}
-
-	// Called by the connection layer after retries are exhausted. For an
-	// instance we already reached, treat it as a poweroff so the user can wait.
-	// For a host we never connected to (e.g. a typo'd deep link), the offline
-	// status screen is more honest than "Server is shutting down".
-	function handleGiveUp() {
-		if (instance?.connectedAt) powerEvent = 'poweroff';
-	}
 
 	function startWaiting() {
 		waiting = true;
 		// Restart retries - give-up may have stopped them (common on mobile after backgrounding)
-		if (currentSSEId !== null) {
-			appState.connectOne(currentSSEId, { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp });
-		}
+		if (connectedId !== null) appState.connectOne(connectedId, powerCallbacks);
 	}
 
 	function dismiss() {
@@ -145,39 +141,18 @@
 		push('/');
 	}
 
-	function attachSSE(id: string) {
-		if (currentSSEId !== null) appState.disconnectOne(currentSSEId);
-		currentSSEId = null;
-		serverWentOffline = false;
-		waiting = false;
-		// CORS blocks the probe but not the iframe - skip the keepalive so the
-		// give-up timer can't trigger a misleading poweroff overlay.
-		if (appState.findById(id)?.status === 'cors') return;
-		currentSSEId = id;
-		appState.connectOne(id, { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp });
-	}
-
-	function detachSSE() {
-		if (currentSSEId !== null) {
-			const id = currentSSEId;
-			currentSSEId = null;
-			// Hand the connection back to the background pool (no power callbacks)
-			// so the list view still shows fresh status after we leave.
-			appState.connectOne(id);
-		}
-	}
-
-	onMount(() => {
-		return () => detachSSE();
-	});
-
 	function switchTo(id: string) {
 		powerEvent = null;
 		appState.openInstance(id);
 	}
 
 	function handleBack() {
-		if (instance?.transient) {
+		// Only prompt to save when the instance is actually connectable - asking
+		// the user to save an unreachable host would be pointless.
+		if (
+			instance?.transient &&
+			(instance.status === 'online' || instance.status === 'cors')
+		) {
 			appState.savePromptVisible = true;
 		} else {
 			push('/');

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -1,12 +1,53 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { push } from 'svelte-spa-router';
 	import { appState } from '../lib/state.svelte';
 	import { getInstanceUiUrl } from '../lib/api';
 	import type { PowerEvent } from '../lib/types';
 	import InstanceTopBar from './InstanceTopBar.svelte';
 	import PowerScreen from './PowerScreen.svelte';
+	import SavePrompt from './SavePrompt.svelte';
 
-	const instance = $derived(appState.activeInstance);
+	const DEFAULT_PORT = 8018;
+
+	let { params }: { params: { host: string; port?: string | null } } = $props();
+
+	const host = $derived(decodeURIComponent(params.host || '').trim());
+	const port = $derived.by(() => {
+		if (!params.port) return DEFAULT_PORT;
+		const n = parseInt(params.port, 10);
+		return Number.isFinite(n) && n >= 1 && n <= 65535 ? n : NaN;
+	});
+	const labelFromUrl = $derived(
+		new URLSearchParams(router.querystring ?? '').get('label')?.trim() || undefined,
+	);
+
+	// Invalid port (non-numeric or out of range) - bounce to the list so the
+	// user gets a real view instead of a blank page.
+	$effect(() => {
+		if (host && !Number.isFinite(port)) push('/');
+	});
+
+	// Find or transiently add the instance matching the route params. If we
+	// created it and the user neither saved nor discarded, the cleanup removes
+	// it so unsaved hosts don't pile up across route changes.
+	$effect(() => {
+		if (!host || !Number.isFinite(port)) return;
+		let createdId: string | null = null;
+		if (!appState.findByHostPort(host, port)) {
+			createdId = appState.addInstance(host, port, labelFromUrl, { transient: true });
+		}
+		return () => {
+			if (!createdId) return;
+			if (appState.findById(createdId)?.transient) {
+				appState.removeInstance(createdId);
+			}
+		};
+	});
+
+	const instance = $derived(
+		host && Number.isFinite(port) ? appState.findByHostPort(host, port) : undefined,
+	);
 	const uiUrl = $derived(instance ? getInstanceUiUrl(instance.host, instance.port) : '');
 	const displayName = $derived(
 		instance?.label ||
@@ -18,9 +59,9 @@
 	let serverWentOffline = $state(false);
 	let waiting = $state(false); // user chose to wait during poweroff
 	let iframeKey = $state(0);
-	let currentSSEId: string | null = null; // plain JS — must not be $state
+	let currentSSEId: string | null = null; // plain JS - must not be $state
 
-	// Two-phase detection — reboot always auto-reconnects, poweroff only if user chose to wait.
+	// Two-phase detection - reboot always auto-reconnects, poweroff only if user chose to wait.
 	$effect(() => {
 		if (powerEvent !== null) {
 			if (instance?.status === 'offline' || instance?.status === 'probing') {
@@ -35,26 +76,58 @@
 	});
 
 	// Status can flip to cors after the first probe (e.g. a transient instance
-	// opened via URL params). Drop the keepalive so the give-up timer can't
-	// trigger a misleading poweroff overlay.
+	// opened via URL). Drop the keepalive so the give-up timer can't trigger a
+	// misleading poweroff overlay.
 	$effect(() => {
 		if (instance?.status === 'cors' && currentSSEId !== null) {
 			detachSSE();
 		}
 	});
 
+	// Attach/detach SSE in sync with the resolved instance. Re-runs when the
+	// route switches to a different host/port (e.g. via the TopBar switcher).
+	$effect(() => {
+		const id = instance?.id;
+		if (!id) return;
+		if (id === currentSSEId) return;
+		attachSSE(id);
+		return () => {
+			if (currentSSEId === id) detachSSE();
+		};
+	});
+
+	// Trap browser back/forward while a transient instance is open so the user
+	// gets the same Save prompt as the in-app back button. We push a sentinel
+	// entry; popstate then re-arms it and surfaces the dialog instead of
+	// letting the navigation through. On teardown (Save / Don't save / unmount)
+	// we pop the sentinel so the user doesn't have to back through a phantom
+	// history entry to leave.
+	$effect(() => {
+		if (!instance?.transient) return;
+		history.pushState({ odioGuard: true }, '');
+		function onPopState() {
+			history.pushState({ odioGuard: true }, '');
+			appState.savePromptVisible = true;
+		}
+		window.addEventListener('popstate', onPopState);
+		return () => {
+			window.removeEventListener('popstate', onPopState);
+			if (history.state?.odioGuard) history.back();
+		};
+	});
+
 	function handlePowerAction(action: PowerEvent) {
 		powerEvent = action;
 	}
 
-	// Called by the connection layer after retries are exhausted — treat as poweroff.
+	// Called by the connection layer after retries are exhausted - treat as poweroff.
 	function handleGiveUp() {
 		powerEvent = 'poweroff';
 	}
 
 	function startWaiting() {
 		waiting = true;
-		// Restart retries — give-up may have stopped them (common on mobile after backgrounding)
+		// Restart retries - give-up may have stopped them (common on mobile after backgrounding)
 		if (currentSSEId !== null) {
 			appState.connectOne(currentSSEId, { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp });
 		}
@@ -63,8 +136,7 @@
 	function dismiss() {
 		powerEvent = null;
 		waiting = false;
-		history.back();
-		appState.goToList();
+		push('/');
 	}
 
 	function attachSSE(id: string) {
@@ -72,35 +144,76 @@
 		currentSSEId = null;
 		serverWentOffline = false;
 		waiting = false;
-		// CORS blocks the probe but not the iframe — skip the keepalive so the
+		// CORS blocks the probe but not the iframe - skip the keepalive so the
 		// give-up timer can't trigger a misleading poweroff overlay.
-		if (instance?.status === 'cors') return;
+		if (appState.findById(id)?.status === 'cors') return;
 		currentSSEId = id;
 		appState.connectOne(id, { onPowerAction: handlePowerAction, onGiveUp: handleGiveUp });
 	}
 
 	function detachSSE() {
 		if (currentSSEId !== null) {
-			appState.disconnectOne(currentSSEId);
+			const id = currentSSEId;
 			currentSSEId = null;
+			// Hand the connection back to the background pool (no power callbacks)
+			// so the list view still shows fresh status after we leave.
+			appState.connectOne(id);
 		}
 	}
 
 	onMount(() => {
-		if (instance?.id) attachSSE(instance.id);
 		return () => detachSSE();
 	});
 
 	function switchTo(id: string) {
 		powerEvent = null;
-		attachSSE(id);
 		appState.openInstance(id);
+	}
+
+	function handleBack() {
+		if (instance?.transient) {
+			appState.savePromptVisible = true;
+		} else {
+			push('/');
+		}
+	}
+
+	function leaveToList() {
+		appState.savePromptVisible = false;
+		push('/');
+	}
+
+	function saveTransient() {
+		if (!instance) return;
+		appState.persistInstance(instance.id);
+		appState.savePromptVisible = false;
+	}
+
+	function savePromptSave() {
+		if (instance) appState.persistInstance(instance.id);
+		leaveToList();
+	}
+
+	function savePromptDiscard() {
+		if (instance) appState.removeInstance(instance.id);
+		leaveToList();
+	}
+
+	function savePromptCancel() {
+		appState.savePromptVisible = false;
 	}
 </script>
 
 {#if instance}
 	<div class="instance-view">
-		<InstanceTopBar {displayName} currentId={instance.id} onswitchto={switchTo} />
+		<InstanceTopBar
+			{displayName}
+			currentId={instance.id}
+			onswitchto={switchTo}
+			onback={handleBack}
+			transient={!!instance.transient}
+			onsave={saveTransient}
+		/>
 
 		{#if powerEvent !== null}
 			<PowerScreen event={powerEvent} {waiting} onstartwaiting={startWaiting} ondismiss={dismiss} />
@@ -108,6 +221,15 @@
 			{#key iframeKey}
 				<iframe src={uiUrl} title="odio-api UI - {displayName}" class="instance-iframe" allow="autoplay; fullscreen"></iframe>
 			{/key}
+		{/if}
+
+		{#if appState.savePromptVisible && instance.transient}
+			<SavePrompt
+				{displayName}
+				onsave={savePromptSave}
+				ondiscard={savePromptDiscard}
+				oncancel={savePromptCancel}
+			/>
 		{/if}
 	</div>
 {/if}

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -73,6 +73,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	mockInstance.status = 'online';
 	mockInstance.transient = undefined;
+	mockInstance.connectedAt = undefined;
 	capturedCallbacks.onPowerAction = undefined;
 	capturedCallbacks.onGiveUp = undefined;
 	mockState.savePromptVisible = false;
@@ -193,22 +194,33 @@ describe('InstanceView — poweroff', () => {
 		expect(document.querySelector('iframe')).not.toBeInTheDocument();
 	});
 
-	test('onGiveUp callback triggers the poweroff choice screen', () => {
+	test('onGiveUp callback triggers the poweroff choice screen for a previously-connected instance', () => {
+		mockInstance.connectedAt = Date.now();
 		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onGiveUp?.());
 		expect(screen.getByText('Server is shutting down')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Wait' })).toBeInTheDocument();
 	});
 
+	test('onGiveUp on a never-connected host stays on the offline screen, no fake "shutting down"', () => {
+		mockInstance.connectedAt = undefined;
+		mockInstance.status = 'offline';
+		render(InstanceView, defaultParams);
+		flushSync(() => capturedCallbacks.onGiveUp?.());
+		expect(screen.queryByText('Server is shutting down')).not.toBeInTheDocument();
+		expect(screen.getByText('Server unreachable')).toBeInTheDocument();
+	});
+
 	test('dismiss button routes to /', async () => {
 		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
-		const powerScreen = document.querySelector<HTMLElement>('.power-screen')!;
+		const powerScreen = document.querySelector<HTMLElement>('.status-screen')!;
 		await fireEvent.click(within(powerScreen).getByRole('button', { name: /back to list/i }));
 		expect(push).toHaveBeenCalledWith('/');
 	});
 
 	test('clicking Wait restarts the connection', async () => {
+		mockInstance.connectedAt = Date.now();
 		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onGiveUp?.());
 		await fireEvent.click(screen.getByRole('button', { name: 'Wait' }));
@@ -235,6 +247,72 @@ describe('InstanceView — cors', () => {
 		mockInstance.status = 'cors';
 		render(InstanceView, defaultParams);
 		expect(appState.connectOne).not.toHaveBeenCalled();
+	});
+
+	test('renders the iframe when status is cors', () => {
+		mockInstance.status = 'cors';
+		render(InstanceView, defaultParams);
+		expect(document.querySelector('iframe')).toBeInTheDocument();
+	});
+});
+
+// ── connection status screen ──────────────────────────────────────────────────
+
+describe('InstanceView — connection status screen', () => {
+	test('shows "Connecting" when status is probing, no iframe', () => {
+		mockInstance.status = 'probing';
+		render(InstanceView, defaultParams);
+		expect(screen.getByText(/Connecting to/)).toBeInTheDocument();
+		expect(document.querySelector('iframe')).not.toBeInTheDocument();
+	});
+
+	test('shows "Connecting" when status is unknown, no iframe', () => {
+		mockInstance.status = 'unknown';
+		render(InstanceView, defaultParams);
+		expect(screen.getByText(/Connecting to/)).toBeInTheDocument();
+		expect(document.querySelector('iframe')).not.toBeInTheDocument();
+	});
+
+	test('shows "Server unreachable" when status is offline, no iframe', () => {
+		mockInstance.status = 'offline';
+		render(InstanceView, defaultParams);
+		expect(screen.getByText('Server unreachable')).toBeInTheDocument();
+		expect(document.querySelector('iframe')).not.toBeInTheDocument();
+	});
+
+	test('shows "Browser blocked" when status is blocked, no iframe', () => {
+		mockInstance.status = 'blocked';
+		render(InstanceView, defaultParams);
+		expect(screen.getByText(/Browser blocked/)).toBeInTheDocument();
+		expect(document.querySelector('iframe')).not.toBeInTheDocument();
+	});
+
+	test('back button on the Connecting screen routes to /', async () => {
+		mockInstance.status = 'probing';
+		mockInstance.transient = false;
+		render(InstanceView, defaultParams);
+		const screenEl = document.querySelector<HTMLElement>('.status-screen')!;
+		await fireEvent.click(within(screenEl).getByRole('button', { name: /back to list/i }));
+		expect(push).toHaveBeenCalledWith('/');
+	});
+
+	test('back button on the offline screen routes to / for a saved instance', async () => {
+		mockInstance.status = 'offline';
+		mockInstance.transient = false;
+		render(InstanceView, defaultParams);
+		const screenEl = document.querySelector<HTMLElement>('.status-screen')!;
+		await fireEvent.click(within(screenEl).getByRole('button', { name: /back to list/i }));
+		expect(push).toHaveBeenCalledWith('/');
+	});
+
+	test('back button on the offline screen of a transient instance opens the save prompt', async () => {
+		mockInstance.status = 'offline';
+		mockInstance.transient = true;
+		render(InstanceView, defaultParams);
+		const screenEl = document.querySelector<HTMLElement>('.status-screen')!;
+		await fireEvent.click(within(screenEl).getByRole('button', { name: /back to list/i }));
+		expect(mockState.savePromptVisible).toBe(true);
+		expect(push).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -118,7 +118,7 @@ describe('InstanceView — poweroff', () => {
 	test('dismiss button calls appState.goToList', async () => {
 		render(InstanceView);
 		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
-		const powerScreen = document.querySelector('.power-screen')!;
+		const powerScreen = document.querySelector<HTMLElement>('.power-screen')!;
 		await fireEvent.click(within(powerScreen).getByRole('button', { name: /back to list/i }));
 		expect(appState.goToList).toHaveBeenCalledOnce();
 	});

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -243,10 +243,13 @@ describe('InstanceView — poweroff', () => {
 // ── cors ──────────────────────────────────────────────────────────────────────
 
 describe('InstanceView — cors', () => {
-	test('skips the keepalive when status is cors — iframe still loads, probe retries are futile', () => {
+	test('connects with callbacks even when status is cors (probe layer skips retries on its own)', () => {
 		mockInstance.status = 'cors';
 		render(InstanceView, defaultParams);
-		expect(appState.connectOne).not.toHaveBeenCalled();
+		expect(appState.connectOne).toHaveBeenCalledWith('1', {
+			onPowerAction: expect.any(Function),
+			onGiveUp: expect.any(Function),
+		});
 	});
 
 	test('renders the iframe when status is cors', () => {
@@ -305,14 +308,14 @@ describe('InstanceView — connection status screen', () => {
 		expect(push).toHaveBeenCalledWith('/');
 	});
 
-	test('back button on the offline screen of a transient instance opens the save prompt', async () => {
+	test('back button on the offline screen routes to / even for a transient instance', async () => {
 		mockInstance.status = 'offline';
 		mockInstance.transient = true;
 		render(InstanceView, defaultParams);
 		const screenEl = document.querySelector<HTMLElement>('.status-screen')!;
 		await fireEvent.click(within(screenEl).getByRole('button', { name: /back to list/i }));
-		expect(mockState.savePromptVisible).toBe(true);
-		expect(push).not.toHaveBeenCalled();
+		expect(push).toHaveBeenCalledWith('/');
+		expect(mockState.savePromptVisible).toBe(false);
 	});
 });
 
@@ -357,16 +360,27 @@ describe('InstanceView — transient', () => {
 		expect(mockState.savePromptVisible).toBe(false);
 	});
 
-	test('back button on a transient instance shows the save prompt instead of leaving', async () => {
+	test('back button on a transient online instance shows the save prompt', async () => {
 		mockInstance.transient = true;
+		mockInstance.status = 'online';
 		render(InstanceView, defaultParams);
 		await fireEvent.click(screen.getByTitle('Back to list'));
 		expect(mockState.savePromptVisible).toBe(true);
 		expect(push).not.toHaveBeenCalled();
 	});
 
-	test('browser back (popstate) on a transient instance shows the save prompt', () => {
+	test('back button on a transient offline instance just routes to / (no point saving an unreachable host)', async () => {
 		mockInstance.transient = true;
+		mockInstance.status = 'offline';
+		render(InstanceView, defaultParams);
+		await fireEvent.click(screen.getByTitle('Back to list'));
+		expect(push).toHaveBeenCalledWith('/');
+		expect(mockState.savePromptVisible).toBe(false);
+	});
+
+	test('browser back (popstate) on a transient online instance shows the save prompt', () => {
+		mockInstance.transient = true;
+		mockInstance.status = 'online';
 		render(InstanceView, defaultParams);
 		expect(mockState.savePromptVisible).toBe(false);
 		window.dispatchEvent(new PopStateEvent('popstate'));
@@ -380,26 +394,12 @@ describe('InstanceView — transient', () => {
 		expect(mockState.savePromptVisible).toBe(false);
 	});
 
-	test('pops the sentinel history entry on unmount so no phantom remains', () => {
+	test('browser back is not trapped on a transient offline instance (probe is futile)', () => {
 		mockInstance.transient = true;
-		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
-		const { unmount } = render(InstanceView, defaultParams);
-		// The transient effect pushed our guard.
-		expect(history.state).toEqual({ odioGuard: true });
-		unmount();
-		// Cleanup popped it (history.state reads aren't synchronous in jsdom,
-		// so we verify intent via the spy).
-		expect(back).toHaveBeenCalled();
-		back.mockRestore();
-	});
-
-	test('does not pop on unmount of a non-transient instance', () => {
-		mockInstance.transient = false;
-		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
-		const { unmount } = render(InstanceView, defaultParams);
-		unmount();
-		expect(back).not.toHaveBeenCalled();
-		back.mockRestore();
+		mockInstance.status = 'offline';
+		render(InstanceView, defaultParams);
+		window.dispatchEvent(new PopStateEvent('popstate'));
+		expect(mockState.savePromptVisible).toBe(false);
 	});
 });
 

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -153,6 +153,16 @@ describe('InstanceView — poweroff', () => {
 	});
 });
 
+// ── cors ──────────────────────────────────────────────────────────────────────
+
+describe('InstanceView — cors', () => {
+	test('skips the keepalive when status is cors — iframe still loads, probe retries are futile', () => {
+		mockInstance.status = 'cors';
+		render(InstanceView);
+		expect(appState.connectOne).not.toHaveBeenCalled();
+	});
+});
+
 // ── switchTo ──────────────────────────────────────────────────────────────────
 
 describe('InstanceView — switchTo', () => {

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -29,7 +29,7 @@ const mockState = vi.hoisted(() => ({ savePromptVisible: false }));
 
 vi.mock('../lib/state.svelte', () => ({
 	appState: {
-		get onlineInstances() { return [mockInstance, mockInstance2]; },
+		get connectableInstances() { return [mockInstance, mockInstance2]; },
 		get savePromptVisible() { return mockState.savePromptVisible; },
 		set savePromptVisible(v: boolean) { mockState.savePromptVisible = v; },
 		findByHostPort: vi.fn((host: string, port: number) => {

--- a/src/components/InstanceView.test.ts
+++ b/src/components/InstanceView.test.ts
@@ -25,19 +25,38 @@ const capturedCallbacks = vi.hoisted(() => ({
 	onGiveUp: undefined as (() => void) | undefined,
 }));
 
+const mockState = vi.hoisted(() => ({ savePromptVisible: false }));
+
 vi.mock('../lib/state.svelte', () => ({
 	appState: {
-		get activeInstance() { return mockInstance; },
 		get onlineInstances() { return [mockInstance, mockInstance2]; },
+		get savePromptVisible() { return mockState.savePromptVisible; },
+		set savePromptVisible(v: boolean) { mockState.savePromptVisible = v; },
+		findByHostPort: vi.fn((host: string, port: number) => {
+			if (host === mockInstance.host && port === mockInstance.port) return mockInstance;
+			if (host === mockInstance2.host && port === mockInstance2.port) return mockInstance2;
+			return undefined;
+		}),
+		findById: vi.fn((id: string) => {
+			if (id === mockInstance.id) return mockInstance;
+			if (id === mockInstance2.id) return mockInstance2;
+			return undefined;
+		}),
+		addInstance: vi.fn(),
 		connectOne: vi.fn((_id: string, extra?: { onPowerAction?: (a: PowerEvent) => void; onGiveUp?: () => void }) => {
 			capturedCallbacks.onPowerAction = extra?.onPowerAction;
 			capturedCallbacks.onGiveUp = extra?.onGiveUp;
 		}),
 		disconnectOne: vi.fn(),
-		goToList: vi.fn(),
 		openInstance: vi.fn(),
+		persistInstance: vi.fn(),
+		removeInstance: vi.fn(),
 	},
 }));
+
+const mockRouter = vi.hoisted(() => ({ querystring: '' }));
+
+vi.mock('svelte-spa-router', () => ({ push: vi.fn(), router: mockRouter }));
 
 vi.mock('../lib/api', () => ({
 	getInstanceUiUrl: (host: string, port: number) => `http://${host}:${port}/ui`,
@@ -45,35 +64,104 @@ vi.mock('../lib/api', () => ({
 
 import InstanceView from './InstanceView.svelte';
 import { appState } from '../lib/state.svelte';
+import { push } from 'svelte-spa-router';
+
+const params = (host: string, port?: string) => ({ params: { host, port: port ?? null } });
+const defaultParams = params('192.168.1.1', '8080');
 
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockInstance.status = 'online';
+	mockInstance.transient = undefined;
 	capturedCallbacks.onPowerAction = undefined;
 	capturedCallbacks.onGiveUp = undefined;
+	mockState.savePromptVisible = false;
+	mockRouter.querystring = '';
+	history.replaceState(null, '', '/');
 });
 
 // ── normal state ──────────────────────────────────────────────────────────────
 
 describe('InstanceView — normal state', () => {
 	test('shows the iframe when no power event', () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		expect(document.querySelector('iframe')).toBeInTheDocument();
 		expect(screen.queryByText('Server is rebooting')).not.toBeInTheDocument();
 	});
 
 	test('connects SSE with power callbacks on mount', () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		expect(appState.connectOne).toHaveBeenCalledWith('1', {
 			onPowerAction: expect.any(Function),
 			onGiveUp: expect.any(Function),
 		});
 	});
 
-	test('disconnects SSE on unmount', () => {
-		const { unmount } = render(InstanceView);
+	test('hands the connection back to the background pool on unmount (no power callbacks)', () => {
+		const { unmount } = render(InstanceView, defaultParams);
+		vi.mocked(appState.connectOne).mockClear();
 		unmount();
-		expect(appState.disconnectOne).toHaveBeenCalledWith('1');
+		// Reconnects without callbacks so the list view keeps live status.
+		expect(appState.connectOne).toHaveBeenCalledWith('1');
+		expect(appState.connectOne).toHaveBeenCalledTimes(1);
+	});
+
+	test('creates a transient instance when no match exists for the route params', () => {
+		render(InstanceView, params('10.0.0.99', '9000'));
+		expect(appState.addInstance).toHaveBeenCalledWith('10.0.0.99', 9000, undefined, { transient: true });
+	});
+
+	test('reads label from the router querystring on transient creation', () => {
+		mockRouter.querystring = 'label=Salon';
+		render(InstanceView, params('10.0.0.99', '9000'));
+		expect(appState.addInstance).toHaveBeenCalledWith('10.0.0.99', 9000, 'Salon', { transient: true });
+	});
+
+	test('redirects to / when the port is not a valid number', () => {
+		render(InstanceView, params('10.0.0.99', 'abc'));
+		expect(push).toHaveBeenCalledWith('/');
+		expect(appState.addInstance).not.toHaveBeenCalled();
+	});
+
+	test('redirects to / when the port is out of range', () => {
+		render(InstanceView, params('10.0.0.99', '99999'));
+		expect(push).toHaveBeenCalledWith('/');
+		expect(appState.addInstance).not.toHaveBeenCalled();
+	});
+
+	test('removes the transient instance on unmount when not saved', () => {
+		const txId = 'tx-1';
+		const tx: OdioInstance = {
+			id: txId, host: '10.0.0.99', port: 9000, status: 'unknown', transient: true,
+		};
+		vi.mocked(appState.addInstance).mockReturnValue(txId);
+		vi.mocked(appState.findById).mockImplementation((id: string) => {
+			if (id === txId) return tx;
+			if (id === '1') return mockInstance;
+			if (id === '2') return mockInstance2;
+			return undefined;
+		});
+		const { unmount } = render(InstanceView, params('10.0.0.99', '9000'));
+		expect(appState.addInstance).toHaveBeenCalledOnce();
+		unmount();
+		expect(appState.removeInstance).toHaveBeenCalledWith(txId);
+	});
+
+	test('does not remove an instance that has been saved before unmount', () => {
+		const txId = 'tx-2';
+		const saved: OdioInstance = {
+			id: txId, host: '10.0.0.99', port: 9000, status: 'online', transient: false,
+		};
+		vi.mocked(appState.addInstance).mockReturnValue(txId);
+		vi.mocked(appState.findById).mockImplementation((id: string) => {
+			if (id === txId) return saved;
+			if (id === '1') return mockInstance;
+			if (id === '2') return mockInstance2;
+			return undefined;
+		});
+		const { unmount } = render(InstanceView, params('10.0.0.99', '9000'));
+		unmount();
+		expect(appState.removeInstance).not.toHaveBeenCalled();
 	});
 });
 
@@ -81,19 +169,16 @@ describe('InstanceView — normal state', () => {
 
 describe('InstanceView — reboot', () => {
 	test('shows the reboot screen when power.action reboot is received', () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('reboot'));
 		expect(screen.getByText('Server is rebooting')).toBeInTheDocument();
 		expect(document.querySelector('iframe')).not.toBeInTheDocument();
 	});
 
 	test('does not auto-reconnect while server is still online (regression)', () => {
-		// Bug: the old $effect triggered immediately because status was 'online'
-		// when power.action arrived, before the server had a chance to go offline.
 		mockInstance.status = 'online';
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('reboot'));
-		// Reboot screen must stay visible — server hasn't gone offline yet
 		expect(screen.getByText('Server is rebooting')).toBeInTheDocument();
 	});
 });
@@ -102,39 +187,29 @@ describe('InstanceView — reboot', () => {
 
 describe('InstanceView — poweroff', () => {
 	test('shows the poweroff screen when power.action poweroff is received', () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
 		expect(screen.getByText('Server is shutting down')).toBeInTheDocument();
 		expect(document.querySelector('iframe')).not.toBeInTheDocument();
 	});
 
 	test('onGiveUp callback triggers the poweroff choice screen', () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onGiveUp?.());
 		expect(screen.getByText('Server is shutting down')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Wait' })).toBeInTheDocument();
 	});
 
-	test('dismiss button calls appState.goToList', async () => {
-		render(InstanceView);
+	test('dismiss button routes to /', async () => {
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
 		const powerScreen = document.querySelector<HTMLElement>('.power-screen')!;
 		await fireEvent.click(within(powerScreen).getByRole('button', { name: /back to list/i }));
-		expect(appState.goToList).toHaveBeenCalledOnce();
-	});
-
-	test('dismiss button calls history.back()', async () => {
-		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
-		render(InstanceView);
-		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
-		const powerScreen = document.querySelector('.power-screen')!;
-		await fireEvent.click(within(powerScreen).getByRole('button', { name: /back to list/i }));
-		expect(back).toHaveBeenCalledOnce();
-		back.mockRestore();
+		expect(push).toHaveBeenCalledWith('/');
 	});
 
 	test('clicking Wait restarts the connection', async () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onGiveUp?.());
 		await fireEvent.click(screen.getByRole('button', { name: 'Wait' }));
 		expect(appState.connectOne).toHaveBeenCalledTimes(2); // mount + restart
@@ -145,7 +220,7 @@ describe('InstanceView — poweroff', () => {
 	});
 
 	test('clicking Wait switches to waiting spinner', async () => {
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		flushSync(() => capturedCallbacks.onPowerAction?.('poweroff'));
 		await fireEvent.click(screen.getByRole('button', { name: 'Wait' }));
 		expect(screen.getByText(/Waiting for comeback/)).toBeInTheDocument();
@@ -158,7 +233,7 @@ describe('InstanceView — poweroff', () => {
 describe('InstanceView — cors', () => {
 	test('skips the keepalive when status is cors — iframe still loads, probe retries are futile', () => {
 		mockInstance.status = 'cors';
-		render(InstanceView);
+		render(InstanceView, defaultParams);
 		expect(appState.connectOne).not.toHaveBeenCalled();
 	});
 });
@@ -166,16 +241,165 @@ describe('InstanceView — cors', () => {
 // ── switchTo ──────────────────────────────────────────────────────────────────
 
 describe('InstanceView — switchTo', () => {
-	test('switches SSE connection and opens the selected instance', async () => {
-		render(InstanceView);
-		// Open the instance switcher dropdown
+	test('switching opens the selected instance via the router', async () => {
+		render(InstanceView, defaultParams);
 		await fireEvent.click(screen.getByTitle('Switch instance'));
-		// Click the second instance (Pi2, not the current one)
 		await fireEvent.click(screen.getByText('Pi2'));
-		expect(appState.connectOne).toHaveBeenLastCalledWith('2', expect.objectContaining({
-			onPowerAction: expect.any(Function),
-			onGiveUp: expect.any(Function),
-		}));
 		expect(appState.openInstance).toHaveBeenCalledWith('2');
+	});
+});
+
+// ── transient instance ────────────────────────────────────────────────────────
+
+describe('InstanceView — transient', () => {
+	test('Save button in the top bar is hidden for non-transient instances', () => {
+		mockInstance.transient = false;
+		render(InstanceView, defaultParams);
+		expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+	});
+
+	test('Save button in the top bar is shown for transient instances', () => {
+		mockInstance.transient = true;
+		render(InstanceView, defaultParams);
+		expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+	});
+
+	test('clicking the Save button calls persistInstance with the instance id', async () => {
+		mockInstance.transient = true;
+		render(InstanceView, defaultParams);
+		await fireEvent.click(screen.getByRole('button', { name: /save/i }));
+		expect(appState.persistInstance).toHaveBeenCalledWith('1');
+	});
+
+	test('back button on a non-transient instance routes to /', async () => {
+		mockInstance.transient = false;
+		render(InstanceView, defaultParams);
+		await fireEvent.click(screen.getByTitle('Back to list'));
+		expect(push).toHaveBeenCalledWith('/');
+		expect(mockState.savePromptVisible).toBe(false);
+	});
+
+	test('back button on a transient instance shows the save prompt instead of leaving', async () => {
+		mockInstance.transient = true;
+		render(InstanceView, defaultParams);
+		await fireEvent.click(screen.getByTitle('Back to list'));
+		expect(mockState.savePromptVisible).toBe(true);
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	test('browser back (popstate) on a transient instance shows the save prompt', () => {
+		mockInstance.transient = true;
+		render(InstanceView, defaultParams);
+		expect(mockState.savePromptVisible).toBe(false);
+		window.dispatchEvent(new PopStateEvent('popstate'));
+		expect(mockState.savePromptVisible).toBe(true);
+	});
+
+	test('browser back is not trapped on a non-transient instance', () => {
+		mockInstance.transient = false;
+		render(InstanceView, defaultParams);
+		window.dispatchEvent(new PopStateEvent('popstate'));
+		expect(mockState.savePromptVisible).toBe(false);
+	});
+
+	test('pops the sentinel history entry on unmount so no phantom remains', () => {
+		mockInstance.transient = true;
+		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
+		const { unmount } = render(InstanceView, defaultParams);
+		// The transient effect pushed our guard.
+		expect(history.state).toEqual({ odioGuard: true });
+		unmount();
+		// Cleanup popped it (history.state reads aren't synchronous in jsdom,
+		// so we verify intent via the spy).
+		expect(back).toHaveBeenCalled();
+		back.mockRestore();
+	});
+
+	test('does not pop on unmount of a non-transient instance', () => {
+		mockInstance.transient = false;
+		const back = vi.spyOn(history, 'back').mockImplementation(() => {});
+		const { unmount } = render(InstanceView, defaultParams);
+		unmount();
+		expect(back).not.toHaveBeenCalled();
+		back.mockRestore();
+	});
+});
+
+// ── save prompt ───────────────────────────────────────────────────────────────
+
+describe('InstanceView — save prompt', () => {
+	test('does not render when savePromptVisible is false', () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = false;
+		render(InstanceView, defaultParams);
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	test('does not render when the instance is not transient (defensive)', () => {
+		mockInstance.transient = false;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	test('renders when both flags are set', () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		expect(screen.getByRole('dialog', { name: /save this instance/i })).toBeInTheDocument();
+	});
+
+	test('Save action persists the instance and routes to /', async () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		const dialog = screen.getByRole('dialog');
+		await fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+		expect(appState.persistInstance).toHaveBeenCalledWith('1');
+		expect(mockState.savePromptVisible).toBe(false);
+		expect(push).toHaveBeenCalledWith('/');
+	});
+
+	test("Don't save action removes the transient instance and routes to /", async () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		const dialog = screen.getByRole('dialog');
+		await fireEvent.click(within(dialog).getByRole('button', { name: /don't save/i }));
+		expect(appState.removeInstance).toHaveBeenCalledWith('1');
+		expect(mockState.savePromptVisible).toBe(false);
+		expect(push).toHaveBeenCalledWith('/');
+		expect(appState.persistInstance).not.toHaveBeenCalled();
+	});
+
+	test('Cancel action only hides the prompt — no navigation or persistence', async () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		const dialog = screen.getByRole('dialog');
+		await fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+		expect(mockState.savePromptVisible).toBe(false);
+		expect(push).not.toHaveBeenCalled();
+		expect(appState.persistInstance).not.toHaveBeenCalled();
+		expect(appState.removeInstance).not.toHaveBeenCalled();
+	});
+
+	test('Escape key closes the prompt without persisting or navigating', () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = true;
+		render(InstanceView, defaultParams);
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(mockState.savePromptVisible).toBe(false);
+		expect(push).not.toHaveBeenCalled();
+		expect(appState.persistInstance).not.toHaveBeenCalled();
+		expect(appState.removeInstance).not.toHaveBeenCalled();
+	});
+
+	test('Escape key is a no-op when the prompt is closed', () => {
+		mockInstance.transient = true;
+		mockState.savePromptVisible = false;
+		render(InstanceView, defaultParams);
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(mockState.savePromptVisible).toBe(false);
 	});
 });

--- a/src/components/PowerScreen.svelte
+++ b/src/components/PowerScreen.svelte
@@ -14,22 +14,22 @@
 	} = $props();
 </script>
 
-<div class="power-screen" role="status">
+<div class="status-screen" role="status">
 	{#if event === 'reboot' || waiting}
-		<svg class="power-screen-icon spin" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+		<svg class="status-screen-icon spin" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
 			<polyline points="23 4 23 10 17 10" />
 			<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
 		</svg>
-		<h2 class="power-screen-title">{event === 'reboot' ? 'Server is rebooting' : 'Server is shutting down'}</h2>
-		<p class="power-screen-body">Waiting for comeback&hellip;</p>
+		<h2 class="status-screen-title">{event === 'reboot' ? 'Server is rebooting' : 'Server is shutting down'}</h2>
+		<p class="status-screen-body">Waiting for comeback&hellip;</p>
 	{:else}
-		<svg class="power-screen-icon" style="color: var(--warning)" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+		<svg class="status-screen-icon" style="color: var(--warning)" viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
 			<path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
 			<line x1="12" y1="2" x2="12" y2="12" />
 		</svg>
-		<h2 class="power-screen-title">Server is shutting down</h2>
-		<p class="power-screen-body">Do you want to wait for it to come back?</p>
-		<div class="power-screen-actions">
+		<h2 class="status-screen-title">Server is shutting down</h2>
+		<p class="status-screen-body">Do you want to wait for it to come back?</p>
+		<div class="status-screen-actions">
 			<button class="btn-primary" onclick={onstartwaiting}>Wait</button>
 			<button class="btn-secondary" onclick={ondismiss}>Back to list</button>
 		</div>

--- a/src/components/ReloadPrompt.svelte
+++ b/src/components/ReloadPrompt.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
-	import { useRegisterSW } from 'virtual:pwa-register/svelte';
+	import type { Writable } from 'svelte/store';
 
-	const { offlineReady, needRefresh, updateServiceWorker } = useRegisterSW({
-		onRegisteredSW(_swUrl: string, registration: ServiceWorkerRegistration | undefined) {
-			if (registration) {
-				setInterval(() => registration.update(), 60 * 60 * 1000);
-			}
-		},
-		onRegisterError(error: unknown) {
-			console.error('SW registration error:', error);
-		},
-	});
+	let {
+		offlineReady,
+		needRefresh,
+		updateServiceWorker,
+	}: {
+		offlineReady: Writable<boolean>;
+		needRefresh: Writable<boolean>;
+		updateServiceWorker: (reloadPage?: boolean) => Promise<void>;
+	} = $props();
 
 	function close() {
 		$offlineReady = false;

--- a/src/components/ReloadPrompt.test.ts
+++ b/src/components/ReloadPrompt.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { writable, type Writable } from 'svelte/store';
+import ReloadPrompt from './ReloadPrompt.svelte';
+
+let offlineReady: Writable<boolean>;
+let needRefresh: Writable<boolean>;
+let updateServiceWorker: (reloadPage?: boolean) => Promise<void>;
+
+beforeEach(() => {
+	offlineReady = writable(false);
+	needRefresh = writable(false);
+	updateServiceWorker = vi.fn(async () => {});
+});
+
+function renderPrompt() {
+	return render(ReloadPrompt, { offlineReady, needRefresh, updateServiceWorker });
+}
+
+// ── hidden state ──────────────────────────────────────────────────────────────
+
+describe('ReloadPrompt — hidden', () => {
+	test('renders nothing when neither flag is set', () => {
+		renderPrompt();
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});
+
+// ── offline ready ─────────────────────────────────────────────────────────────
+
+describe('ReloadPrompt — offline ready', () => {
+	beforeEach(() => {
+		offlineReady.set(true);
+	});
+
+	test('shows the offline-ready toast', () => {
+		renderPrompt();
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+		expect(screen.getByText('App ready to work offline')).toBeInTheDocument();
+	});
+
+	test('does not show the Reload button (no update available)', () => {
+		renderPrompt();
+		expect(screen.queryByRole('button', { name: 'Reload' })).not.toBeInTheDocument();
+	});
+
+	test('shows the Close button', () => {
+		renderPrompt();
+		expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+	});
+});
+
+// ── update available ──────────────────────────────────────────────────────────
+
+describe('ReloadPrompt — update available', () => {
+	beforeEach(() => {
+		needRefresh.set(true);
+	});
+
+	test('shows the new-content toast', () => {
+		renderPrompt();
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+		expect(screen.getByText('New content available')).toBeInTheDocument();
+	});
+
+	test('Reload button calls updateServiceWorker(true)', async () => {
+		renderPrompt();
+		await fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
+		expect(updateServiceWorker).toHaveBeenCalledWith(true);
+	});
+
+	test('shows the Close button alongside Reload', () => {
+		renderPrompt();
+		expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument();
+	});
+});
+
+// ── close ─────────────────────────────────────────────────────────────────────
+
+describe('ReloadPrompt — close', () => {
+	test('Close clears both stores and hides the toast', async () => {
+		offlineReady.set(true);
+		needRefresh.set(true);
+		renderPrompt();
+		await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});

--- a/src/components/SavePrompt.svelte
+++ b/src/components/SavePrompt.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	let {
+		displayName,
+		onsave,
+		ondiscard,
+		oncancel,
+	}: {
+		displayName: string;
+		onsave: () => void;
+		ondiscard: () => void;
+		oncancel: () => void;
+	} = $props();
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') oncancel();
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="save-prompt-backdrop" onclick={oncancel}></div>
+<div class="save-prompt" role="dialog" aria-modal="true" aria-labelledby="save-prompt-title">
+	<h3 id="save-prompt-title">Save this instance?</h3>
+	<p>Add {displayName} to your list so you can come back to it later.</p>
+	<div class="save-prompt-actions">
+		<button class="btn-primary" onclick={onsave}>Save</button>
+		<button class="btn-secondary" onclick={ondiscard}>Don't save</button>
+		<button class="btn-secondary" onclick={oncancel}>Cancel</button>
+	</div>
+</div>

--- a/src/components/SavePrompt.test.ts
+++ b/src/components/SavePrompt.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SavePrompt from './SavePrompt.svelte';
+
+const noop = () => {};
+
+function renderPrompt(overrides: Partial<{
+	displayName: string;
+	onsave: () => void;
+	ondiscard: () => void;
+	oncancel: () => void;
+}> = {}) {
+	return render(SavePrompt, {
+		displayName: 'Living Room',
+		onsave: noop,
+		ondiscard: noop,
+		oncancel: noop,
+		...overrides,
+	});
+}
+
+// ── render ────────────────────────────────────────────────────────────────────
+
+describe('SavePrompt — render', () => {
+	test('shows the dialog with the display name', () => {
+		renderPrompt({ displayName: 'Living Room' });
+		expect(screen.getByRole('dialog', { name: /save this instance/i })).toBeInTheDocument();
+		expect(screen.getByText(/Add Living Room to your list/)).toBeInTheDocument();
+	});
+
+	test('renders Save / Don\'t save / Cancel buttons', () => {
+		renderPrompt();
+		expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /don't save/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+	});
+});
+
+// ── actions ───────────────────────────────────────────────────────────────────
+
+describe('SavePrompt — actions', () => {
+	test('"Save" calls onsave', async () => {
+		const onsave = vi.fn();
+		renderPrompt({ onsave });
+		await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+		expect(onsave).toHaveBeenCalledOnce();
+	});
+
+	test('"Don\'t save" calls ondiscard', async () => {
+		const ondiscard = vi.fn();
+		renderPrompt({ ondiscard });
+		await fireEvent.click(screen.getByRole('button', { name: /don't save/i }));
+		expect(ondiscard).toHaveBeenCalledOnce();
+	});
+
+	test('"Cancel" calls oncancel', async () => {
+		const oncancel = vi.fn();
+		renderPrompt({ oncancel });
+		await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(oncancel).toHaveBeenCalledOnce();
+	});
+
+	test('clicking the backdrop calls oncancel', async () => {
+		const oncancel = vi.fn();
+		renderPrompt({ oncancel });
+		const backdrop = document.querySelector('.save-prompt-backdrop')!;
+		await fireEvent.click(backdrop);
+		expect(oncancel).toHaveBeenCalledOnce();
+	});
+});
+
+// ── keyboard ──────────────────────────────────────────────────────────────────
+
+describe('SavePrompt — keyboard', () => {
+	test('Escape calls oncancel', () => {
+		const oncancel = vi.fn();
+		renderPrompt({ oncancel });
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+		expect(oncancel).toHaveBeenCalledOnce();
+	});
+
+	test('other keys do nothing', () => {
+		const oncancel = vi.fn();
+		renderPrompt({ oncancel });
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+		window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+		expect(oncancel).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/appstate.test.ts
+++ b/src/lib/appstate.test.ts
@@ -4,10 +4,12 @@ import type { SSEExtraCallbacks } from './sse';
 // Mock dependencies before importing AppState
 vi.mock('./sse', () => ({ connectSSE: vi.fn() }));
 vi.mock('./api', () => ({ probeInstance: vi.fn() }));
+vi.mock('svelte-spa-router', () => ({ push: vi.fn() }));
 
-import { AppState } from './state.svelte';
+import { AppState, instancePath } from './state.svelte';
 import { connectSSE } from './sse';
 import { probeInstance } from './api';
+import { push } from 'svelte-spa-router';
 
 // --- helpers ---
 
@@ -98,6 +100,83 @@ describe('addInstance', () => {
 	});
 });
 
+describe('addInstance — transient', () => {
+	test('adds an instance flagged as transient', () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080, 'pi', { transient: true });
+		expect(s.instances[0]).toMatchObject({ host: '192.168.1.1', transient: true });
+	});
+
+	test('does not persist transient instances to localStorage', () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080, undefined, { transient: true });
+		expect(localStorage.getItem('odio-instances')).toBeNull();
+	});
+
+	test('still opens an SSE connection for transient instances', async () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080, undefined, { transient: true });
+		await flushPromises();
+		expect(connectSSE).toHaveBeenCalledOnce();
+	});
+
+	test('returns the new instance id', () => {
+		const s = new AppState();
+		const id = s.addInstance('192.168.1.1', 8080);
+		expect(id).toBe(s.instances[0].id);
+	});
+
+	test('saving an existing connectedAt does not leak the transient one to storage', async () => {
+		// onServerInfo persists to storage; the transient flag must filter it out.
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080, undefined, { transient: true });
+		await flushPromises();
+		await lastSSE().onOpen(); // triggers saveInstances via onServerInfo
+		expect(localStorage.getItem('odio-instances')).toBe('[]');
+	});
+});
+
+describe('persistInstance', () => {
+	test('clears the transient flag and writes to localStorage', () => {
+		const s = new AppState();
+		const id = s.addInstance('192.168.1.1', 8080, 'pi', { transient: true });
+		s.persistInstance(id);
+		expect(s.instances[0].transient).toBe(false);
+		const saved = JSON.parse(localStorage.getItem('odio-instances')!);
+		expect(saved).toHaveLength(1);
+		expect(saved[0]).toMatchObject({ host: '192.168.1.1', label: 'pi' });
+	});
+
+	test('is a no-op for non-transient instances', () => {
+		const s = new AppState();
+		const id = s.addInstance('192.168.1.1', 8080);
+		localStorage.clear();
+		s.persistInstance(id);
+		expect(localStorage.getItem('odio-instances')).toBeNull();
+	});
+
+	test('is a no-op for unknown ids', () => {
+		const s = new AppState();
+		expect(() => s.persistInstance('does-not-exist')).not.toThrow();
+	});
+});
+
+describe('findByHostPort', () => {
+	test('returns the matching instance', () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080);
+		s.addInstance('192.168.1.2', 9090);
+		expect(s.findByHostPort('192.168.1.2', 9090)?.host).toBe('192.168.1.2');
+	});
+
+	test('returns undefined when host:port does not match', () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080);
+		expect(s.findByHostPort('10.0.0.1', 8080)).toBeUndefined();
+		expect(s.findByHostPort('192.168.1.1', 9090)).toBeUndefined();
+	});
+});
+
 describe('removeInstance', () => {
 	test('removes the instance from the array', async () => {
 		const s = new AppState();
@@ -117,26 +196,14 @@ describe('removeInstance', () => {
 		expect(cleanup).toHaveBeenCalledOnce();
 	});
 
-	test('navigates back to list when the active instance is removed', async () => {
+	test('removes from the instances list and from localStorage', async () => {
 		const s = new AppState();
 		s.addInstance('192.168.1.1', 8080);
 		await flushPromises();
 		const id = s.instances[0].id;
-		s.openInstance(id);
-		expect(s.currentView).toBe('instance');
 		s.removeInstance(id);
-		expect(s.currentView).toBe('list');
-		expect(s.activeInstanceId).toBeNull();
-	});
-
-	test('does not affect view when a non-active instance is removed', async () => {
-		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
-		s.addInstance('192.168.1.2', 8080);
-		await flushPromises();
-		s.openInstance(s.instances[0].id);
-		s.removeInstance(s.instances[1].id);
-		expect(s.currentView).toBe('instance');
+		expect(s.instances).toHaveLength(0);
+		expect(JSON.parse(localStorage.getItem('odio-instances') || '[]')).toEqual([]);
 	});
 });
 
@@ -166,56 +233,46 @@ describe('updateInstance', () => {
 
 // ─── Navigation ─────────────────────────────────────────────────────────────
 
-describe('openInstance / goToList', () => {
-	test('openInstance sets view and activeInstanceId', () => {
+describe('openInstance / goToList / instancePath', () => {
+	test('openInstance routes to /i/<host> for default port 8018', () => {
 		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
-		const id = s.instances[0].id;
-		s.openInstance(id);
-		expect(s.currentView).toBe('instance');
-		expect(s.activeInstanceId).toBe(id);
+		s.addInstance('192.168.1.1', 8018);
+		s.openInstance(s.instances[0].id);
+		expect(push).toHaveBeenCalledWith('/i/192.168.1.1');
 	});
 
-	test('goToList resets the view', () => {
+	test('openInstance includes the port when not default', () => {
 		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
+		s.addInstance('192.168.1.1', 9000);
 		s.openInstance(s.instances[0].id);
+		expect(push).toHaveBeenCalledWith('/i/192.168.1.1/9000');
+	});
+
+	test('openInstance encodes host and label safely', () => {
+		const s = new AppState();
+		s.addInstance('my server', 9000, 'Living Room');
+		s.openInstance(s.instances[0].id);
+		expect(push).toHaveBeenCalledWith('/i/my%20server/9000?label=Living%20Room');
+	});
+
+	test('openInstance is a no-op when the id is unknown', () => {
+		const s = new AppState();
+		s.openInstance('no-such-id');
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	test('goToList routes to /', () => {
+		const s = new AppState();
 		s.goToList();
-		expect(s.currentView).toBe('list');
+		expect(push).toHaveBeenCalledWith('/');
 	});
 
-	test('activeInstance returns the correct instance', () => {
-		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080, 'pi');
-		const id = s.instances[0].id;
-		s.openInstance(id);
-		expect(s.activeInstance?.label).toBe('pi');
-	});
-
-	test('activeInstance returns undefined when on the list view', () => {
-		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
-		expect(s.activeInstance).toBeUndefined();
-	});
-
-	test('pushes a history entry when navigating list → instance', () => {
-		const push = vi.spyOn(history, 'pushState');
-		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
-		s.openInstance(s.instances[0].id);
-		expect(push).toHaveBeenCalledOnce();
-		push.mockRestore();
-	});
-
-	test('replaces history entry when switching instance → instance', () => {
-		const s = new AppState();
-		s.addInstance('192.168.1.1', 8080);
-		s.addInstance('192.168.1.2', 8080);
-		s.openInstance(s.instances[0].id); // list → instance
-		const replace = vi.spyOn(history, 'replaceState');
-		s.openInstance(s.instances[1].id); // instance → instance
-		expect(replace).toHaveBeenCalledOnce();
-		replace.mockRestore();
+	test('instancePath builder matches the openInstance routing', () => {
+		expect(instancePath('192.168.1.1', 8018)).toBe('/i/192.168.1.1');
+		expect(instancePath('192.168.1.1', 9000)).toBe('/i/192.168.1.1/9000');
+		expect(instancePath('my server', 9000, 'Living Room')).toBe(
+			'/i/my%20server/9000?label=Living%20Room',
+		);
 	});
 });
 
@@ -244,7 +301,7 @@ describe('connectOne / disconnectOne', () => {
 		expect(connectSSE).toHaveBeenCalledOnce();
 	});
 
-	test('connectOne forwards onPowerAction to connectSSE', async () => {
+	test('connectOne wires onPowerAction so connectSSE forwards events to it', async () => {
 		const s = new AppState();
 		s.addInstance('192.168.1.1', 8080);
 		const id = s.instances[0].id;
@@ -253,7 +310,40 @@ describe('connectOne / disconnectOne', () => {
 		captured = [];
 		s.connectOne(id, { onPowerAction });
 		await flushPromises();
-		expect(lastSSE().extra?.onPowerAction).toBe(onPowerAction);
+		lastSSE().extra?.onPowerAction?.('reboot');
+		expect(onPowerAction).toHaveBeenCalledWith('reboot');
+	});
+
+	test('connectOne is idempotent for the connection - second call only swaps callbacks', async () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080);
+		await flushPromises(); // initial connection from addInstance
+		vi.clearAllMocks();
+		captured = [];
+		const onPowerAction = vi.fn();
+		s.connectOne(s.instances[0].id, { onPowerAction });
+		await flushPromises();
+		// No new SSE: the existing connection's callbacks were updated in place.
+		expect(connectSSE).not.toHaveBeenCalled();
+	});
+
+	test('connectOne lets a re-attached onPowerAction fire on subsequent power events', async () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080);
+		await flushPromises();
+		const id = s.instances[0].id;
+		const sse = lastSSE();
+		// Foreground attaches with callbacks, then drops them.
+		const onPowerAction = vi.fn();
+		s.connectOne(id, { onPowerAction });
+		s.connectOne(id); // hand back to background pool
+		sse.extra?.onPowerAction?.('reboot');
+		expect(onPowerAction).not.toHaveBeenCalled();
+		// Re-attach with new callbacks - same connection, new wrapper target.
+		const onPowerAction2 = vi.fn();
+		s.connectOne(id, { onPowerAction: onPowerAction2 });
+		sse.extra?.onPowerAction?.('poweroff');
+		expect(onPowerAction2).toHaveBeenCalledWith('poweroff');
 	});
 
 	test('disconnectOne calls the cleanup and removes the entry', async () => {
@@ -284,16 +374,29 @@ describe('connectOne / disconnectOne', () => {
 });
 
 describe('connectAll / disconnectAll', () => {
-	test('connectAll opens SSE for every instance', async () => {
+	test('connectAll opens SSE for every instance that is not already connected', async () => {
 		const s = new AppState();
 		s.addInstance('192.168.1.1', 8080);
 		s.addInstance('192.168.1.2', 8080);
 		await flushPromises(); // drain initial connections
+		s.disconnectAll();
 		vi.clearAllMocks();
 		captured = [];
 		s.connectAll();
 		await flushPromises();
 		expect(connectSSE).toHaveBeenCalledTimes(2);
+	});
+
+	test('connectAll is idempotent — leaves existing SSE connections in place', async () => {
+		const s = new AppState();
+		s.addInstance('192.168.1.1', 8080);
+		s.addInstance('192.168.1.2', 8080);
+		await flushPromises(); // drain initial connections (2 SSE)
+		vi.clearAllMocks();
+		captured = [];
+		s.connectAll(); // should be a no-op since both are already connected
+		await flushPromises();
+		expect(connectSSE).not.toHaveBeenCalled();
 	});
 
 	test('disconnectAll calls every cleanup', async () => {

--- a/src/lib/appstate.test.ts
+++ b/src/lib/appstate.test.ts
@@ -31,7 +31,7 @@ function flushPromises(): Promise<void> {
 type CapturedSSE = {
 	host: string;
 	port: number;
-	onOpen: () => Promise<void>;
+	onOpen: () => void;
 	onAlive: () => void;
 	onOffline: () => void;
 	extra?: SSEExtraCallbacks;

--- a/src/lib/appstate.test.ts
+++ b/src/lib/appstate.test.ts
@@ -510,24 +510,39 @@ describe('onOffline callback', () => {
 	});
 });
 
-// ─── onlineInstances ─────────────────────────────────────────────────────────
+// ─── connectableInstances ────────────────────────────────────────────────────
 
-describe('onlineInstances', () => {
-	test('returns only instances whose status is online', () => {
+describe('connectableInstances', () => {
+	test('includes online instances', () => {
 		const s = new AppState();
 		s.addInstance('192.168.1.1', 8080);
 		s.addInstance('192.168.1.2', 8080);
 		s.instances[0].status = 'online';
 		s.instances[1].status = 'offline';
-		expect(s.onlineInstances).toHaveLength(1);
-		expect(s.onlineInstances[0].host).toBe('192.168.1.1');
+		expect(s.connectableInstances).toHaveLength(1);
+		expect(s.connectableInstances[0].host).toBe('192.168.1.1');
 	});
 
-	test('returns empty array when no instance is online', () => {
+	test('includes cors instances - the iframe still loads without API CORS headers', () => {
 		const s = new AppState();
 		s.addInstance('192.168.1.1', 8080);
+		s.addInstance('192.168.1.2', 8080);
+		s.instances[0].status = 'online';
+		s.instances[1].status = 'cors';
+		expect(s.connectableInstances).toHaveLength(2);
+	});
+
+	test('excludes offline, blocked, probing, unknown', () => {
+		const s = new AppState();
+		s.addInstance('a', 1);
+		s.addInstance('b', 1);
+		s.addInstance('c', 1);
+		s.addInstance('d', 1);
 		s.instances[0].status = 'offline';
-		expect(s.onlineInstances).toHaveLength(0);
+		s.instances[1].status = 'blocked';
+		s.instances[2].status = 'probing';
+		s.instances[3].status = 'unknown';
+		expect(s.connectableInstances).toHaveLength(0);
 	});
 });
 

--- a/src/lib/connection.test.ts
+++ b/src/lib/connection.test.ts
@@ -274,15 +274,16 @@ describe('createConnection — visibility change', () => {
 		expect(cb.onStatus).toHaveBeenCalledWith('online');
 	});
 
-	test('does nothing when no retry is pending', async () => {
+	test('forces a fresh attempt even with no retry pending — covers silent SSE drops while backgrounded', async () => {
 		vi.useFakeTimers();
 		const cb = makeCallbacks();
 		createConnection('h', 8080, cb);
 		await drainMicrotasks(); // probe ok → SSE opened, no retry timer
-		cb.onStatus.mockClear();
+		cb.onServerInfo.mockClear();
 		document.dispatchEvent(new Event('visibilitychange'));
 		await drainMicrotasks();
-		expect(cb.onStatus).not.toHaveBeenCalled();
+		// A fresh probe should run, refreshing serverInfo.
+		expect(cb.onServerInfo).toHaveBeenCalled();
 	});
 
 	test('destroy removes the listener', async () => {

--- a/src/lib/connection.test.ts
+++ b/src/lib/connection.test.ts
@@ -138,6 +138,20 @@ describe('createConnection — probe failure', () => {
 		expect(reachable).not.toHaveBeenCalled();
 	});
 
+	test('does not schedule a retry when probe fails with CORS', async () => {
+		vi.useFakeTimers();
+		vi.mocked(probeInstance).mockRejectedValue(new TypeError('Failed to fetch'));
+		vi.mocked(probeReachable).mockResolvedValue(true);
+		const cb = makeCallbacks();
+		createConnection('h', 8080, cb);
+		await drainMicrotasks();
+		expect(cb.onStatus).toHaveBeenCalledWith('cors');
+		await vi.advanceTimersByTimeAsync(GIVE_UP_AFTER_MS + 1_000);
+		// One probe only - no retry, no give-up.
+		expect(probeInstance).toHaveBeenCalledOnce();
+		expect(cb.onGiveUp).not.toHaveBeenCalled();
+	});
+
 	test('retries after backoff on probe failure', async () => {
 		vi.useFakeTimers();
 		vi.mocked(probeInstance).mockRejectedValue(new Error('down'));

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -110,7 +110,12 @@ export function createConnection(
 	// Does NOT affect SSE support state.
 	async function onProbeFailure(err: unknown) {
 		const status = await classifyProbeFailure(err, host, port);
-		if (!destroyed) callbacks.onStatus(status);
+		if (destroyed) return;
+		callbacks.onStatus(status);
+		// CORS means the server is reachable but missing Access-Control-Allow-Origin.
+		// Headers won't appear on their own, retrying just spams the console.
+		// A visibilitychange can still trigger a fresh probe in case config changed.
+		if (status === 'cors') return;
 		scheduleRetry();
 	}
 

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -66,12 +66,16 @@ export function createConnection(
 	let sseEverOpened = false;
 	let effectiveUseSSE = options.useSSE ?? true;
 
+	// Mobile browsers commonly drop background SSE silently; always force a
+	// fresh attempt on resume so reconnection doesn't wait for the next
+	// scheduled probe.
 	function onVisibilityChange() {
-		if (document.visibilityState === 'visible' && retryTimer !== null) {
+		if (document.visibilityState !== 'visible' || destroyed) return;
+		if (retryTimer !== null) {
 			clearTimeout(retryTimer);
 			retryTimer = null;
-			attempt();
 		}
+		attempt();
 	}
 	document.addEventListener('visibilitychange', onVisibilityChange);
 
@@ -126,6 +130,12 @@ export function createConnection(
 
 	async function attempt() {
 		if (destroyed) return;
+		// Close any lingering SSE so a re-entered attempt (e.g. visibilitychange
+		// while the stream was open) doesn't double up.
+		if (closeSSE !== null) {
+			closeSSE();
+			closeSSE = null;
+		}
 		// Show 'probing' only on the first attempt — during retries stay 'offline'
 		// to avoid red→yellow flickering on the homepage for a known-down server.
 		if (failingSince === null) callbacks.onStatus('probing');

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -69,8 +69,10 @@ export class AppState {
 	// the callbacks instead of tearing down and re-firing the probe.
 	private foregroundCallbacks = new Map<string, InstanceCallbacks>();
 
-	get onlineInstances(): OdioInstance[] {
-		return this.instances.filter((i) => i.status === 'online');
+	// Instances the user can actually switch to: SSE up, or up-but-no-CORS-headers
+	// (the iframe still loads in that case).
+	get connectableInstances(): OdioInstance[] {
+		return this.instances.filter((i) => i.status === 'online' || i.status === 'cors');
 	}
 
 	get sortedInstances(): OdioInstance[] {

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,8 +1,10 @@
-import type { OdioInstance, AppView } from './types';
+import type { OdioInstance } from './types';
 import { createConnection } from './connection';
+import { push } from 'svelte-spa-router';
 
 const STORAGE_KEY = 'odio-instances';
 const SSE_LIMIT = 6;
+const DEFAULT_PORT = 8018;
 
 function loadInstances(): OdioInstance[] {
 	try {
@@ -20,14 +22,16 @@ function loadInstances(): OdioInstance[] {
 }
 
 function saveInstances(instances: OdioInstance[]): void {
-	const toSave = instances.map(({ id, host, port, label, serverInfo, connectedAt }) => ({
-		id,
-		host,
-		port,
-		label,
-		serverInfo,
-		connectedAt,
-	}));
+	const toSave = instances
+		.filter((i) => !i.transient)
+		.map(({ id, host, port, label, serverInfo, connectedAt }) => ({
+			id,
+			host,
+			port,
+			label,
+			serverInfo,
+			connectedAt,
+		}));
 	localStorage.setItem(STORAGE_KEY, JSON.stringify(toSave));
 }
 
@@ -39,6 +43,14 @@ export function byPriority(a: OdioInstance, b: OdioInstance): number {
 	return (b.connectedAt ?? 0) - (a.connectedAt ?? 0);
 }
 
+export function instancePath(host: string, port: number, label?: string): string {
+	const base = port === DEFAULT_PORT
+		? `/i/${encodeURIComponent(host)}`
+		: `/i/${encodeURIComponent(host)}/${port}`;
+	if (!label) return base;
+	return `${base}?label=${encodeURIComponent(label)}`;
+}
+
 export interface InstanceCallbacks {
 	onPowerAction?: (action: 'reboot' | 'poweroff') => void;
 	onGiveUp?: () => void;
@@ -46,16 +58,16 @@ export interface InstanceCallbacks {
 
 export class AppState {
 	instances: OdioInstance[] = $state(loadInstances());
-	currentView: AppView = $state('list');
-	activeInstanceId: string | null = $state(null);
+	savePromptVisible: boolean = $state(false);
 
 	// SSE connections (max SSE_LIMIT); polling connections for the rest
 	private sseConnections = new Map<string, () => void>();
 	private pollConnections = new Map<string, () => void>();
-
-	get activeInstance(): OdioInstance | undefined {
-		return this.instances.find((i) => i.id === this.activeInstanceId);
-	}
+	// Power callbacks set by InstanceView while it's the foreground view.
+	// Looked up dynamically inside the connection wrappers, so a second
+	// connectOne (e.g. background pool then foreground attach) just swaps
+	// the callbacks instead of tearing down and re-firing the probe.
+	private foregroundCallbacks = new Map<string, InstanceCallbacks>();
 
 	get onlineInstances(): OdioInstance[] {
 		return this.instances.filter((i) => i.status === 'online');
@@ -65,14 +77,31 @@ export class AppState {
 		return [...this.instances].sort(byPriority);
 	}
 
-	addInstance(host: string, port: number, label?: string): void {
+	addInstance(host: string, port: number, label?: string, opts: { transient?: boolean } = {}): string {
 		const id = crypto.randomUUID();
-		this.instances.push({ id, host, port, label, status: 'unknown', serverInfo: null });
-		saveInstances(this.instances);
+		this.instances.push({ id, host, port, label, status: 'unknown', serverInfo: null, transient: opts.transient });
+		if (!opts.transient) saveInstances(this.instances);
 		if (this.sseConnections.size < SSE_LIMIT) {
 			this.connectOne(id);
 		} else {
 			this.startPolling(id);
+		}
+		return id;
+	}
+
+	findByHostPort(host: string, port: number): OdioInstance | undefined {
+		return this.instances.find((i) => i.host === host && i.port === port);
+	}
+
+	findById(id: string): OdioInstance | undefined {
+		return this.instances.find((i) => i.id === id);
+	}
+
+	persistInstance(id: string): void {
+		const inst = this.instances.find((i) => i.id === id);
+		if (inst && inst.transient) {
+			inst.transient = false;
+			saveInstances(this.instances);
 		}
 	}
 
@@ -83,10 +112,6 @@ export class AppState {
 		if (idx !== -1) {
 			this.instances.splice(idx, 1);
 			saveInstances(this.instances);
-			if (this.activeInstanceId === id) {
-				this.activeInstanceId = null;
-				this.currentView = 'list';
-			}
 		}
 	}
 
@@ -103,23 +128,25 @@ export class AppState {
 	}
 
 	openInstance(id: string): void {
-		if (this.currentView === 'instance') {
-			history.replaceState(null, ''); // switching instance → no extra history entry
-		} else {
-			history.pushState(null, ''); // list → instance: push so back returns to list
-		}
-		this.activeInstanceId = id;
-		this.currentView = 'instance';
+		const inst = this.findById(id);
+		if (inst) push(instancePath(inst.host, inst.port, inst.label));
 	}
 
 	goToList(): void {
-		this.currentView = 'list';
+		push('/');
 	}
 
+	// Idempotent for the connection itself: if there's already an SSE up for
+	// this id, only the foreground callbacks are swapped. Pass extras to
+	// register power callbacks (foreground); call without extras to drop
+	// them (hand back to background pool). Use disconnectOne / probeOne
+	// when you actually need to tear down and re-fire the probe.
 	connectOne(id: string, extra?: InstanceCallbacks): void {
 		const inst = this.instances.find((i) => i.id === id);
 		if (!inst) return;
-		this.disconnectOne(id);
+		if (extra) this.foregroundCallbacks.set(id, extra);
+		else this.foregroundCallbacks.delete(id);
+		if (this.sseConnections.has(id)) return;
 		const destroy = createConnection(inst.host, inst.port, {
 			onStatus: (status) => {
 				inst.status = status;
@@ -129,8 +156,8 @@ export class AppState {
 				inst.connectedAt = Date.now();
 				saveInstances(this.instances);
 			},
-			onGiveUp: extra?.onGiveUp ?? (() => {}),
-			onPowerAction: extra?.onPowerAction,
+			onGiveUp: () => this.foregroundCallbacks.get(id)?.onGiveUp?.(),
+			onPowerAction: (action) => this.foregroundCallbacks.get(id)?.onPowerAction?.(action),
 		});
 		this.sseConnections.set(id, destroy);
 	}
@@ -138,6 +165,7 @@ export class AppState {
 	disconnectOne(id: string): void {
 		this.sseConnections.get(id)?.();
 		this.sseConnections.delete(id);
+		this.foregroundCallbacks.delete(id);
 	}
 
 	private startPolling(id: string): void {
@@ -163,10 +191,18 @@ export class AppState {
 		this.pollConnections.delete(id);
 	}
 
+	// Idempotent: leaves existing connections alone (InstanceView may have
+	// already attached one with power callbacks for the current instance).
 	connectAll(): void {
 		const sorted = this.sortedInstances;
-		sorted.slice(0, SSE_LIMIT).forEach((i) => this.connectOne(i.id));
-		sorted.slice(SSE_LIMIT).forEach((i) => this.startPolling(i.id));
+		sorted.slice(0, SSE_LIMIT).forEach((i) => {
+			if (!this.sseConnections.has(i.id)) this.connectOne(i.id);
+		});
+		sorted.slice(SSE_LIMIT).forEach((i) => {
+			if (!this.sseConnections.has(i.id) && !this.pollConnections.has(i.id)) {
+				this.startPolling(i.id);
+			}
+		});
 	}
 
 	disconnectAll(): void {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,8 +21,8 @@ export interface OdioInstance {
 	serverInfo?: OdioServerInfo | null;
 	status: 'unknown' | 'online' | 'offline' | 'probing' | 'blocked' | 'cors';
 	connectedAt?: number;
+	// Loaded from URL params; not persisted to localStorage until the user saves.
+	transient?: boolean;
 }
-
-export type AppView = 'list' | 'instance';
 
 export type PowerEvent = 'reboot' | 'poweroff';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,5 +17,5 @@
     "checkJs": true,
     "moduleDetection": "force"
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "vitest-setup.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,14 +6,24 @@ import { version as pkgVersion } from './package.json';
 
 function gitDescribe(): string | null {
 	try {
-		const raw = execSync('git describe --tags', { stdio: ['ignore', 'pipe', 'ignore'] })
+		const raw = execSync('git describe --tags --always --dirty', { stdio: ['ignore', 'pipe', 'ignore'] })
 			.toString()
 			.trim();
-		// v0.3.4 → 0.3.4 ; v0.3.4-1-g838e075 → 0.3.4+1.g838e075 (semver build-meta)
-		const m = raw.match(/^v?(\d+\.\d+\.\d+)(?:-(\d+)-g([0-9a-f]+))?$/);
-		if (!m) return null;
-		const [, tag, count, sha] = m;
-		return count ? `${tag}+${count}.g${sha}` : tag;
+		if (!raw) return null;
+		// v0.3.4 → 0.3.4
+		// v0.3.4-1-g838e075 → 0.3.4+1.g838e075 (semver build-meta)
+		// + optional -dirty suffix on either of the above
+		const tagged = raw.match(/^v?(\d+\.\d+\.\d+)(?:-(\d+)-g([0-9a-f]+))?(-dirty)?$/);
+		if (tagged) {
+			const [, tag, count, sha, dirty] = tagged;
+			const base = count ? `${tag}+${count}.g${sha}` : tag;
+			return dirty ? `${base}.dirty` : base;
+		}
+		// Vercel ships a shallow clone where the latest tag may be unreachable;
+		// --always then returns a bare SHA. Pair it with the package.json version.
+		const sha = raw.match(/^([0-9a-f]+)(-dirty)?$/);
+		if (sha) return `${pkgVersion}+g${sha[1]}${sha[2] ? '.dirty' : ''}`;
+		return null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
Lets users open a specific instance via ?host=...&port=...&label=... without manually adding it first, so links and QR codes can deep-link straight into the iframe view. The instance is held as transient (in-memory only); a Save button in the top bar persists it, and leaving without saving (in-app or browser back) shows a confirm dialog with Save / Don't save / Cancel.