### PR TITLE
fix: don't reclassify connection failures as blocked once online

### DIFF
--- a/src/lib/connection.test.ts
+++ b/src/lib/connection.test.ts
@@ -191,6 +191,23 @@ describe('createConnection — probe failure', () => {
 		expect(cb.onGiveUp).toHaveBeenCalledOnce();
 	});
 
+	test('after a successful probe, later failures are offline (no re-classification as blocked/cors)', async () => {
+		vi.useFakeTimers();
+		const cb = makeCallbacks();
+		createConnection('h', 8080, cb);
+		await drainMicrotasks(); // first probe ok → online
+		expect(cb.onStatus).toHaveBeenCalledWith('online');
+		// Server goes down - probe + no-cors both fail.
+		vi.mocked(probeInstance).mockRejectedValue(new TypeError('Failed to fetch'));
+		vi.mocked(probeReachable).mockResolvedValue(false);
+		capturedSSE!.onOpen(); // mark sseEverOpened so onSSEDisconnect emits 'offline' (not the fallback path)
+		capturedSSE!.onOffline(); // SSE drops → schedules a retry probe
+		await vi.advanceTimersByTimeAsync(1_000);
+		// The retry probe failed - must be 'offline', never 'blocked' or 'cors'.
+		expect(cb.onStatus).not.toHaveBeenCalledWith('blocked');
+		expect(cb.onStatus).not.toHaveBeenCalledWith('cors');
+	});
+
 	test('destroy cancels pending retry timer', async () => {
 		vi.useFakeTimers();
 		vi.mocked(probeInstance).mockRejectedValue(new Error('down'));

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -66,6 +66,11 @@ export function createConnection(
 	let sseEverOpened = false;
 	let effectiveUseSSE = options.useSSE ?? true;
 
+	// classifyProbeFailure is for first-contact disambiguation. Once we've
+	// reached the server, the browser has obviously permitted the request, so
+	// later failures can't be 'blocked' (mixed content) or 'cors' - just offline.
+	let everOnline = false;
+
 	// Mobile browsers commonly drop background SSE silently; always force a
 	// fresh attempt on resume so reconnection doesn't wait for the next
 	// scheduled probe.
@@ -109,7 +114,7 @@ export function createConnection(
 	// Called when the probe itself fails (server unreachable).
 	// Does NOT affect SSE support state.
 	async function onProbeFailure(err: unknown) {
-		const status = await classifyProbeFailure(err, host, port);
+		const status = everOnline ? 'offline' : await classifyProbeFailure(err, host, port);
 		if (destroyed) return;
 		callbacks.onStatus(status);
 		// CORS means the server is reachable but missing Access-Control-Allow-Origin.
@@ -153,9 +158,10 @@ export function createConnection(
 		}
 		if (destroyed) return;
 
-		// Probe succeeded — reset failure tracking
+		// Probe succeeded - reset failure tracking
 		failingSince = null;
 		backoffMs = BACKOFF_INITIAL_MS;
+		everOnline = true;
 		callbacks.onServerInfo(info);
 		callbacks.onStatus('online');
 


### PR DESCRIPTION
A successful probe means the browser permitted the request, so subsequent failures (server shutdown, network drop) can't legitimately become 'blocked' (mixed-content) or 'cors'. Skip classifyProbeFailure after first success and surface 'offline' directly.