### PR TITLE
feat(seo): structured data, OG/Twitter meta, generated robots/sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,34 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="theme-color" content="#0a1f12" />
-		<meta
-			name="description"
-			content="Discover and control odio-api instances on your local network"
-		/>
-		<title>Odio</title>
+		<meta name="robots" content="index, follow" />
+
+		<title>%TITLE%</title>
+		<meta name="description" content="%DESCRIPTION%" />
+
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
+		<link rel="canonical" href="https://pwa.odio.love/" />
+		<link rel="alternate" hreflang="en" href="https://pwa.odio.love/" />
+		<link rel="alternate" hreflang="x-default" href="https://pwa.odio.love/" />
+
+		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="odio" />
+		<meta property="og:url" content="https://pwa.odio.love/" />
+		<meta property="og:title" content="%TITLE%" />
+		<meta property="og:description" content="%SHORT_DESCRIPTION%" />
+		<meta property="og:image" content="%OG_IMAGE%" />
+		<meta property="og:image:alt" content="%OG_IMAGE_ALT%" />
+
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content="%TITLE%" />
+		<meta name="twitter:description" content="%SHORT_DESCRIPTION%" />
+		<meta name="twitter:image" content="%OG_IMAGE%" />
+		<meta name="twitter:image:alt" content="%OG_IMAGE_ALT%" />
+
+		<script type="application/ld+json">%JSON_LD%</script>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "odio-pwa",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odio-pwa",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "svelte-spa-router": "^5.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odio-pwa",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app.css
+++ b/src/app.css
@@ -646,3 +646,28 @@ button {
 .spin {
 	animation: spin 1.5s linear infinite;
 }
+
+/* Accessibility */
+
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible,
+input:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/src/data/schemas/site.ts
+++ b/src/data/schemas/site.ts
@@ -1,0 +1,107 @@
+export const SITE_URL = 'https://pwa.odio.love';
+export const ODIO_URL = 'https://odio.love';
+export const DOCS_URL = 'https://docs.odio.love';
+export const REPO_URL = 'https://github.com/b0bbywan/odio-pwa';
+
+export const DEFAULT_TITLE = 'Odio Web App - Multimedia remote for your local odio audio nodes';
+
+export const DEFAULT_DESCRIPTION =
+  'Open-source multimedia remote to discover and control your local odio audio nodes. Installable PWA, real-time status, multi-node switching. Free, no account, no telemetry.';
+
+export const SHORT_DESCRIPTION =
+  'Open-source multimedia remote to discover and control your local odio audio nodes. Installable PWA, real-time status, multi-node switching.';
+
+export const OG_IMAGE = `${SITE_URL}/logo.png`;
+export const OG_IMAGE_ALT = 'odio logo';
+
+export const ORG_ID = `${ODIO_URL}/#organization`;
+export const OS_ID = `${ODIO_URL}/#os`;
+
+export interface SchemaRef {
+  '@id': string;
+}
+
+export const ORG_REF: SchemaRef = { '@id': ORG_ID };
+export const OS_REF: SchemaRef = { '@id': OS_ID };
+
+const FEATURE_LIST = [
+  'Discover and add odio nodes by IP or hostname',
+  'Real-time status via Server-Sent Events with HTTP polling fallback',
+  'Smart reconnect with exponential backoff',
+  'One-tap switching between online nodes',
+  'Power event handling (reboot wait, poweroff)',
+  'Installable as a Progressive Web App',
+];
+
+const KEYWORDS = [
+  'odio',
+  'odio web app',
+  'odio remote',
+  'multimedia remote',
+  'audio streamer remote',
+  'Raspberry Pi multimedia remote',
+  'Raspberry Pi audio remote',
+  'multi-node control',
+  'multi-room audio control',
+  'Progressive Web App',
+  'self-hosted multimedia',
+  'self-hosted audio',
+];
+
+export interface BuildSiteSchemaArgs {
+  version: string;
+}
+
+export function buildSiteSchema({ version }: BuildSiteSchemaArgs) {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': ORG_ID,
+        name: 'odio',
+        url: ODIO_URL,
+        logo: {
+          '@type': 'ImageObject',
+          url: `${ODIO_URL}/og-cover.png`,
+        },
+        sameAs: [ODIO_URL, DOCS_URL, 'https://github.com/b0bbywan', REPO_URL],
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${SITE_URL}/#website`,
+        name: 'Odio Web App',
+        url: `${SITE_URL}/`,
+        description: SHORT_DESCRIPTION,
+        inLanguage: 'en',
+        publisher: ORG_REF,
+      },
+      {
+        '@type': 'WebApplication',
+        '@id': `${SITE_URL}/#webapp`,
+        name: 'Odio Web App',
+        url: `${SITE_URL}/`,
+        description:
+          'Progressive Web App to discover and control your local odio audio nodes. Add multiple nodes, see live status over Server-Sent Events, switch between them with one tap, install to your home screen.',
+        applicationCategory: 'MultimediaApplication',
+        applicationSubCategory: 'Multimedia Remote',
+        operatingSystem: 'Any (Progressive Web App)',
+        browserRequirements:
+          'Requires a modern browser with Service Worker and Server-Sent Events support',
+        softwareVersion: version,
+        inLanguage: 'en',
+        isAccessibleForFree: true,
+        license: 'https://opensource.org/licenses/BSD-2-Clause',
+        codeRepository: REPO_URL,
+        softwareHelp: { '@type': 'CreativeWork', url: `${DOCS_URL}/guides/pwa/` },
+        about: OS_REF,
+        author: ORG_REF,
+        publisher: ORG_REF,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+        screenshot: OG_IMAGE,
+        featureList: FEATURE_LIST,
+        keywords: KEYWORDS,
+      },
+    ],
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Link", "value": "</sitemap.xml>; rel=\"sitemap\"" }
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,85 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { VitePWA } from 'vite-plugin-pwa';
 import { version as pkgVersion } from './package.json';
+import {
+	buildSiteSchema,
+	DEFAULT_TITLE,
+	DEFAULT_DESCRIPTION,
+	SHORT_DESCRIPTION,
+	OG_IMAGE,
+	OG_IMAGE_ALT,
+	SITE_URL,
+} from './src/data/schemas/site';
+
+function buildRobotsTxt(): string {
+	return [
+		'User-agent: *',
+		'Content-Signal: search=yes, ai-input=yes, ai-train=yes',
+		'Allow: /',
+		`Sitemap: ${SITE_URL}/sitemap.xml`,
+		'',
+	].join('\n');
+}
+
+function buildSitemapXml(): string {
+	return [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+		'  <url>',
+		`    <loc>${SITE_URL}/</loc>`,
+		'    <changefreq>monthly</changefreq>',
+		'    <priority>1.0</priority>',
+		'  </url>',
+		'</urlset>',
+		'',
+	].join('\n');
+}
+
+function seoPlugin(): Plugin {
+	const jsonLd = JSON.stringify(buildSiteSchema({ version: pkgVersion }));
+	const replacements: Record<string, string> = {
+		'%TITLE%': DEFAULT_TITLE,
+		'%DESCRIPTION%': DEFAULT_DESCRIPTION,
+		'%SHORT_DESCRIPTION%': SHORT_DESCRIPTION,
+		'%OG_IMAGE%': OG_IMAGE,
+		'%OG_IMAGE_ALT%': OG_IMAGE_ALT,
+		'%JSON_LD%': jsonLd,
+	};
+	const generated: Record<string, { body: string; type: string }> = {
+		'/robots.txt': { body: buildRobotsTxt(), type: 'text/plain; charset=utf-8' },
+		'/sitemap.xml': { body: buildSitemapXml(), type: 'application/xml; charset=utf-8' },
+	};
+	return {
+		name: 'odio-seo',
+		transformIndexHtml: {
+			order: 'pre',
+			handler(html) {
+				return html.replace(
+					/%(TITLE|DESCRIPTION|SHORT_DESCRIPTION|OG_IMAGE|OG_IMAGE_ALT|JSON_LD)%/g,
+					(m) => replacements[m] ?? m,
+				);
+			},
+		},
+		configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				const url = req.url?.split('?')[0];
+				const hit = url ? generated[url] : undefined;
+				if (!hit) return next();
+				res.setHeader('Content-Type', hit.type);
+				res.end(hit.body);
+			});
+		},
+		generateBundle() {
+			// Only emit on the Vercel build that serves pwa.odio.love.
+			// Self-hoster zips / Docker images must not ship a robots.txt or
+			// sitemap.xml that points at pwa.odio.love.
+			if (process.env.VERCEL !== '1') return;
+			this.emitFile({ type: 'asset', fileName: 'robots.txt', source: generated['/robots.txt'].body });
+			this.emitFile({ type: 'asset', fileName: 'sitemap.xml', source: generated['/sitemap.xml'].body });
+		},
+	};
+}
 
 export default defineConfig({
 	define: {
@@ -9,13 +87,17 @@ export default defineConfig({
 	},
 	plugins: [
 		svelte(),
+		seoPlugin(),
 		VitePWA({
 			registerType: 'autoUpdate',
 			includeAssets: ['favicon.svg', 'apple-touch-icon-180x180.png'],
 			manifest: {
 				name: 'Odio - Multimedia Remote Controller',
 				short_name: 'Odio',
-				description: 'Discover and control odio-api instances on your local network',
+				description: SHORT_DESCRIPTION,
+				lang: 'en',
+				dir: 'ltr',
+				categories: ['music', 'utilities', 'productivity'],
 				theme_color: '#0a1f12',
 				background_color: '#0a1f12',
 				display: 'standalone',


### PR DESCRIPTION
Mirror odio.love's GEO patterns for pwa.odio.love:
- src/data/schemas/site.ts: Organization + WebSite + WebApplication JSON-LD with shared @id refs back to odio.love (#organization, #os)
- index.html: full canonical, hreflang, OG, Twitter meta; placeholders injected at build from the schema module
- vite.config.ts: seoPlugin generates robots.txt (with Content-Signal) and sitemap.xml from SITE_URL in dev (middleware) and prod (emitFile); manifest enriched with description/lang/dir/categories
- src/app.css: :focus-visible outline + prefers-reduced-motion
- vercel.json: Link rel=sitemap header